### PR TITLE
Add build action for `openrefine` to fix ingestion fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Run the following Kotlin script to take an input `csv` file. The result will be 
 added to `repos.csv` in the root of this project, which serves as the source of repositories that the
 seed job will manage jobs for.
 
-`./add-repos.main.kts csv-file`
+`./add-repos.sh csv-file`
 
 The csv-file argument is expected to be a valid `csv` file, with optional header:
 

--- a/repos.csv
+++ b/repos.csv
@@ -1162,7 +1162,7 @@ OpenLimark/GitFlowSemVerPlugin,develop,8,,gradlew,,true,Build uses Gradle 4.x pr
 OpenNMS/newts,master,8,,maven,,,
 OpenNTF/SocialSDK,master,8,,maven,,,
 OpenOLAT/OpenOLAT,master,11,,maven,,,
-OpenRefine/OpenRefine,master,11,,maven,,,
+OpenRefine/OpenRefine,master,11,,maven,-Dmaven.antrun.skip=true -pl !packaging/pom.xml,,
 OpenRock/OpenDJ,master,8,,maven,,,
 OpenSOC/opensoc-streaming,master,8,,maven,,,
 OpenSeizureDetector/Android_Pebble_SD,master,11,,gradlew,,,


### PR DESCRIPTION
There is an issue with the injection job failing ([slack message link](https://moderneinc.slack.com/archives/C04J4KJMUTW/p1675685675059979?thread_ts=1675675949.025439&cid=C04J4KJMUTW)).
Repository [OpenRefine](https://openrefine.org/) 's [ingestion job fails](https://jenkins.moderne.ninja/job/ingest/job/OpenRefine_OpenRefine/61/console) on an antrun packaging with genisoimage,
This issue can be fixed by adding -Dmaven.antrun.skip=true and -pl !packaging/pom.xml to the goals to skip some plugins ([a successful run](https://jenkins.moderne.ninja/job/ingest/job/OpenRefine_OpenRefine/75/)).

And also update `readme` to up to date,