### PR TITLE
Skip outdated wrappers and bump required Java versions

### DIFF
--- a/parser/src/main/java/io/moderne/jenkins/ingest/Parser.java
+++ b/parser/src/main/java/io/moderne/jenkins/ingest/Parser.java
@@ -57,8 +57,8 @@ public class Parser {
 
     private static CsvRow updateCsvRow(CsvRow csvRow, DataTableRow datatableRow) {
         // Pick minimum required Java version
-        String requiredJavaVersion = datatableRow.requiredJavaVersion();
-        if (requiredJavaVersion != null && !requiredJavaVersion.isBlank() && 8 <= Integer.parseInt(requiredJavaVersion)) {
+        Integer requiredJavaVersion = javaVersion(datatableRow.requiredJavaVersion());
+        if (requiredJavaVersion != null) {
             csvRow = csvRow.withJdkTool("java" + requiredJavaVersion);
         }
 
@@ -77,6 +77,22 @@ public class Parser {
             }
         }
         return csvRow;
+    }
+
+    private static Integer javaVersion(String requiredJavaVersion) {
+        if (requiredJavaVersion == null || requiredJavaVersion.isBlank()) {
+            return null;
+        }
+        int javaVersion = Integer.parseInt(requiredJavaVersion);
+        if (javaVersion <= 8) {
+            return 8;
+        } else if (javaVersion <= 11) {
+            return 11;
+        } else if (javaVersion <= 17) {
+            return 17;
+        } else {
+            return 20;
+        }
     }
 }
 

--- a/repos.csv
+++ b/repos.csv
@@ -52,7 +52,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,15038092523/maven-ssm,master,maven,,java8,,,,
 ,15056158Celest/Internets,master,,,java8,,,,
 ,15061641251/HN,master,maven,,java8,,,,
-,15189611/jumpAop,master,,,java8,,,,
+,15189611/jumpAop,master,,,java8,,,TRUE,Gradle wrapper 4.9 is not supported
 ,15270253630/gmall-parent,main,maven,,java8,,,,
 ,15307388990/FanweLive_android,master,,,java8,,,,
 ,15712311828/JavaWebTemplate,master,maven,,java8,,,,
@@ -88,10 +88,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,1991wangliang/tx-lcn,master,maven,,java8,,,,
 ,1993ALINE/jsondata,master,maven,,java8,,,,
 ,1993hzw/Androids,master,,,java8,,,,
-,1993hzw/Doodle,master,,,java8,,,,
+,1993hzw/Doodle,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,1998lixin/Hardwarecode,master,,,java8,,,,
 ,19MisterX98/SeedcrackerX,master,,,java8,,,,
-,19WAS85/coollection,master,,,java8,,,,
+,19WAS85/coollection,master,,,java8,,,TRUE,Gradle wrapper 4.5.1 is not supported
 ,19pateldurgesh/Goverment_Jobs,master,,,java8,,,,
 ,19skillstolearn/Hotel-Booking-System,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,1MaXimus/MXConverter,master,,,java8,,,,
@@ -110,7 +110,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,1ssqq1lxr/iot_push,master,maven,,java8,,,,
 ,1xiaokaige1/WriteAimlessly,master,maven,,java8,,,,
 ,1yun/controlleradvice,master,maven,,java8,,,,
-,201206030/novel,master,maven,,java8,,,,
+,201206030/novel,master,maven,,java17,,,,
 ,201206030/novel-cloud,master,maven,,java8,,,,
 ,201206030/novel-plus,develop_xxy,maven,,java8,,,,
 ,2017eluk/LoginScreen,master,,,java8,,,,
@@ -231,7 +231,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,52North/WPS,dev,maven,,java8,,,,
 ,52North/WeatherDataCollector,master,maven,,java8,,,,
 ,52North/android-geofeed,master,maven,,java8,,,,
-,52North/arctic-sea,master,maven,,java8,,,,
+,52North/arctic-sea,master,maven,,java11,,,,
 ,52North/common-xml,master,maven,,java8,,,,
 ,52North/ecmwf-dataset-crawl,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,52North/epos,master,maven,,java8,,,,
@@ -331,7 +331,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,870581857/anecdotal-records,master,maven,,java8,,,,
 ,877682067/pro,master,maven,,java8,,,,
 ,88250/solo,master,maven,,java11,,,,
-,88250/symphony,master,maven,,java8,,,,
+,88250/symphony,master,maven,,java11,,,,
 ,888xin/activeMQ,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,89zhulin/spring-boot-seckill,master,maven,,java8,,,,
 ,8God/TwoBirdsExerHost,master,,,java8,,,TRUE,Build uses Gradle 3.x
@@ -449,7 +449,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Activiti/activiti-cloud-gateway,develop,maven,,java8,,,,
 ,Activiti/activiti-unit-test-template,master,maven,,java8,,,,
 ,ActivityWatch/aw-android,master,,,java8,,,,
-,AdAway/AdAway,master,,,java8,,,,
+,AdAway/AdAway,master,,,java11,,,,
 ,AdBlocker-Reborn/AdBlocker_Reborn,master,,,java8,,,,
 ,AdPNugroho/ChatGroupMahasiswa,master,,,java8,,,,
 ,AdRoll/cantor,master,maven,,java8,,,,
@@ -461,7 +461,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,AdamBien/wad,master,maven,,java8,,,,
 ,AdamCraftmaster/8-Queen-Challenge,main,maven,,java8,,,,
 ,AdamCraftmaster/DailyProgramming,main,maven,,java8,,,,
-,AdamCraftmaster/Hangman,main,maven,,java8,,,,
+,AdamCraftmaster/Hangman,main,maven,,java17,,,,
 ,AdamCraftmaster/Prime-Number-Checker,main,maven,,java8,,,,
 ,AdamCraftmaster/RockPaperScissors,main,maven,,java8,,,,
 ,AdamCraftmaster/WeatherAPIcomLibrary,main,,,java8,,,TRUE,Top-level build tool file is missing
@@ -496,7 +496,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,AdoptOpenJDK/IcedTea-Web,master,maven,,java8,,,,
 ,AdoptOpenJDK/jitwatch,master,,,java8,,,,
 ,AdoptOpenJDK/lambda-tutorial,master,maven,,java8,,,,
-,AdoptOpenJDK/mjprof,master,maven,,java8,,,,
+,AdoptOpenJDK/mjprof,master,maven,,java17,,,,
 ,AdrianBZG/Twitter-Follow-Exploit,master,,,java8,,,,
 ,AdrianRomanski/movies-world,master,maven,,java8,,,,
 ,AdrianRomanski/rest-school,master,maven,,java8,,,,
@@ -700,7 +700,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,AlexRogalskiy/trailings,master,maven,,java8,,,,
 ,AlexRogalskiy/webiopi,master,maven,,java8,,,,
 ,AlexStart/thegreattool,master,,,java8,,,TRUE,Top-level build tool file is missing
-,AlexTereshenkov/pybutler,main,maven,,java8,,,,
+,AlexTereshenkov/pybutler,main,maven,,java11,,,,
 ,AlexTereshenkov/shapy,main,maven,,java8,,,,
 ,AlexVak/jhipster-sample-application,master,maven,,java8,,,,
 ,AlexWonga/j2ee_searchPeople,master,maven,,java8,,,,
@@ -954,7 +954,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ApplikeySolutions/OrionPreview,master,,,java8,,,,
 ,Appolica/Flubber,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,Appolica/InteractiveInfoWindowAndroid,master,,,java8,,,TRUE,Top-level build tool file is missing
-,AppsFlyer/donkey,master,maven,,java8,,,,
+,AppsFlyer/donkey,master,maven,,java11,,,,
 ,Appverse/appverse-builder-api,master,maven,,java8,,,,
 ,Apress/pivotal-certified-pro-spring-dev-exam,master,,,java8,,,,
 ,Apress/pro-spring-5,master,,gradle,java8,,,TRUE,requires gradle 5.x but doesn't use wrapper
@@ -1028,7 +1028,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Asonxw/bjpk2,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,Aspsine/EditTextInListView,master,,,java8,,,,
 ,Aspsine/FragmentNavigator,master,,,java8,,,,
-,Aspsine/IRecyclerView,master,,,java8,,,,
+,Aspsine/IRecyclerView,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,Aspsine/MultiThreadDownload,master,,,java8,,,,
 ,Aspsine/SwipeToLoadLayout,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,Asqatasun/Asqatasun,master,maven,,java8,,,,
@@ -1151,7 +1151,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Azure/azure-sqldb-spark,master,maven,,java8,,,,
 ,Azure/azure-storage-android,master,,,java8,,,TRUE,Build uses Gradle 3.x
 ,Azure/batch-jenkins,master,maven,,java8,,,,
-,Azure/dapr-java-workshop,main,maven,,java8,,,,
+,Azure/dapr-java-workshop,main,maven,,java11,,,,
 ,Azure/data-lake-adlstool,master,maven,,java8,,,,
 ,Azure/iotc-android-sample,master,,,java8,,,,
 ,Azure/kafka-connect-cosmosdb-graph,master,maven,,java8,,,,
@@ -1177,7 +1177,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,B3Partners/brmo,master,maven,,java11,,,,
 ,B3Partners/flamingo-ibis,master,maven,,java8,,,,
 ,B3Partners/jdbc-util,master,maven,,java8,,,,
-,B3Partners/kadaster-gds2,master,maven,,java8,,,,
+,B3Partners/kadaster-gds2,master,maven,,java11,,,,
 ,B3Partners/tailormap,master,maven,,java11,,,,
 ,BADRKAC/jhipsterSampleApplication,master,maven,,java8,,,,
 ,BAData/protobuf-converter,master,,,java8,,,,
@@ -1191,7 +1191,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,BMCSoftwareCTO/bmc-policy-plugin,master,maven,,java8,,,,
 ,BMawie/jhipster4,master,maven,,java8,,,,
 ,BNYMellon/CodeKatas,master,maven,,java8,,,,
-,BNYMellon/spring-kata,main,maven,,java8,,,,
+,BNYMellon/spring-kata,main,maven,,java11,,,,
 ,BToyin/LoginApplicationProject,master,maven,,java8,,,,
 ,BabuRRajesh/jhipster-sample-application,master,maven,,java8,,,,
 ,Bachkor/Testing-Purpose,master,maven,,java8,,,,
@@ -1225,7 +1225,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Barteks2x/ForgeTest113,master,,,java8,,,,
 ,Bartosz-D3V/E-Commerce-Full-Stack,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,BartoszJarocki/android-boilerpipe,master,,gradle,java8,,,,
-,BaseXdb/basex,main,maven,,java8,,,,
+,BaseXdb/basex,main,maven,,java11,,,,
 ,Baseflow/PhotoView,master,,,java8,,,,
 ,BaselHorany/ProgressStatusBar,master,,,java8,,,,
 ,Basti098765/jhipster-sample-application,master,maven,,java8,,,,
@@ -1301,7 +1301,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,BingAds/BingAds-Java-SDK,main,maven,,java8,,,,
 ,Bingoliallen/trackerPlugin,main,,,java8,,,,
 ,Binyomin-Cohen/PositionTheMusic,master,,,java8,,,,
-,BioPAX/validator,master,maven,,java8,,,,
+,BioPAX/validator,master,maven,,java11,,,,
 ,BioQwer/jHipster-test,master,maven,,java8,,,,
 ,Bipin2137/FTP-downloader,master,,,java8,,,,
 ,Bipoliaras/Delfi-simuliatorius,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -1310,9 +1310,9 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,BishopFox/rmiscout,master,,,java8,,,,
 ,Bisnode/logback-extras,master,maven,,java8,,,,
 ,Bisnode/opa-gradle-plugin,master,,,java8,,,,
-,Bisnode/ttl-cache,master,,,java8,,,,
+,Bisnode/ttl-cache,master,,,java8,,,TRUE,Gradle wrapper 4.9 is not supported
 ,Bisnode/version-check,develop,,,java8,,,,
-,BitInit/pnd,master,maven,,java8,,,,
+,BitInit/pnd,master,maven,,java17,,,,
 ,BitMEX/api-connectors,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,BitScorpio/bitcoin-explorer,master,maven,,java8,,,,
 ,BitTigerInst/BitTiger-MiniFlickr,master,,,java8,,,,
@@ -1326,10 +1326,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Blackdread/sql-to-jdl,master,maven,,java8,,,,
 ,BladeInShine/cmpe295,master,maven,,java8,,,,
 ,Blakeog123/T.M-Cronin,master,,,java8,,,,
-,Blankeer/MDWechat,v3.0,,,java8,,,,
+,Blankeer/MDWechat,v3.0,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,Blankj/ALog,master,,,java8,,,,
 ,Blankj/AndroidUtilCode,master,,,java8,,,,
-,Blankj/FreeProGuard,master,,,java8,,,,
+,Blankj/FreeProGuard,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,Blankj/RxBus,master,,,java8,,,,
 ,Blankj/SwipePanel,master,,,java8,,,,
 ,Blaze-AOSP/packages_apps_Jelly,10,,,java8,,,,
@@ -1520,7 +1520,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,CampusIoT/campusiot-app,master,maven,,java8,,,,
 ,CanSIdo/jhipster-sample-application,master,maven,,java8,,,,
 ,CandleCandle/translations-example,master,maven,,java8,,,,
-,CapOfCave/Lichess4J,master,maven,,java8,,,,
+,CapOfCave/Lichess4J,master,maven,,java11,,,,
 ,CapOfCave/visual-selector,master,maven,,java8,,,,
 ,CaptainJack/gradle-bintray,master,,,java8,,,,
 ,CaptainJack/gradle-capjack-bintray,master,,,java8,,,,
@@ -1531,14 +1531,14 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,CaptainJack/gradle-publish,master,,,java8,,,,
 ,CaptainJack/gradle-reposit,master,,,java8,,,,
 ,CaptainJack/kt-inject,master,,,java8,,,,
-,CaptainJack/kt-logging,master,,,java8,,,,
+,CaptainJack/kt-logging,master,,,java11,,,,
 ,CaptainJack/kt-reflect,master,,,java8,,,,
-,CaptainJack/ktjs-reflect,master,,,java8,,,,
+,CaptainJack/ktjs-reflect,master,,,java11,,,,
 ,CaptainJack/lib-kt-logging,master,,,java8,,,,
 ,CaptainJack/lib-kt-reflect,master,,,java8,,,,
 ,CaptainJack/tool-depin,master,,,java8,,,,
 ,CaptainJack/tool-logging,master,,,java8,,,,
-,CaptainJack/tool-reflect,master,,,java8,,,,
+,CaptainJack/tool-reflect,master,,,java11,,,,
 ,CarGuo/CustomActionWebView,master,,,java8,,,,
 ,CarGuo/FrescoUtils,master,,,java8,,,,
 ,CarGuo/GSYRecordWave,master,,,java8,,,,
@@ -1621,7 +1621,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ChenLittlePing/RecyclerCoverFlow,master,,,java8,,,,
 ,ChenPeng89/weixin-java-op,master,maven,,java8,,,,
 ,ChenSen5/api_autotest,master,maven,,java8,,,,
-,ChenTianSaber/SlideBack,master,,,java8,,,,
+,ChenTianSaber/SlideBack,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,ChengangFeng/TickView,master,,,java8,,,,
 ,ChenjieXu/pyzxing,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,ChennakesavaRaoTummala/micro-online-store,master,maven,,java8,,,,
@@ -1684,7 +1684,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ChuckkNorris/jhipster-angular,master,maven,,java8,,,,
 ,Chungsaeha/Project,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,ChurchTao/green-hat,master,maven,,java8,,,,
-,CibaTheDev/BotCovidLab,master,maven,,java8,,,,
+,CibaTheDev/BotCovidLab,master,maven,,java11,,,,
 ,Cicizz/jmqtt,master,maven,,java8,,,,
 ,Ciiborg/AI15Projet,master,maven,,java8,,,,
 ,Ciiborg/test,master,maven,,java8,,,,
@@ -1844,11 +1844,11 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ComputationalReflection/ExampleClasses,main,maven,,java8,,,,
 ,ConnectSDK/Connect-SDK-Android-API-Sampler,master,,gradle,java8,,,,
 ,ConnectSDK/Connect-SDK-Android-Lite,master,,,java8,,,,
-,Consdata/kouncil,master,maven,,java8,,,,
-,ConsenSys/ethsigner,master,,,java8,,,,
+,Consdata/kouncil,master,maven,,java17,,,,
+,ConsenSys/ethsigner,master,,,java11,,,,
 ,ConsenSys/teku,master,,,java8,,,,
 ,ConsenSys/tessera,master,,,java8,,,,
-,ConsenSys/web3signer,master,,,java8,,,,
+,ConsenSys/web3signer,master,,,java11,,,,
 ,ConsenSys/wittgenstein,master,,gradle,java8,,,,
 ,ConsoleLogLuke/Howl,master,,,java8,,,,
 ,ContainX/openstack4j,master,maven,,java8,,,,
@@ -1884,7 +1884,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Craigacp/FEAST,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,CrawlScript/WebCollector,master,maven,,java8,,,,
 ,CrazyDudo/fvip,master,,,java8,,,,
-,CrazyOrr/FFmpegRecorder,master,,,java8,,,,
+,CrazyOrr/FFmpegRecorder,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,CreativeAshu/jhipster-sample-application,master,maven,,java8,,,,
 ,Creators-of-Create/Create,mc1.18/dev,,,java8,,,,
 ,CreditMutuelArkea/Openstack-Jenkins-HeatPlugin-closed-see-readme-,master,maven,,java8,,,,
@@ -1910,7 +1910,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Cutta/GifView,master,,,java8,,,,
 ,Cutta/MaterialTransitionAnimation,master,,,java8,,,,
 ,Cutta/Simple-Image-Blur,master,,,java8,,,,
-,Cutta/TagView,master,,,java8,,,,
+,Cutta/TagView,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,CwaniX/OpenSUN-Server,master,maven,,java8,,,,
 ,CxAalto/gtfspy,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,CyanogenMod/android_external_libphonenumber,cm-13.0,maven,,java8,,,,
@@ -2059,7 +2059,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,DasNando/LivSec,master,maven,,java8,,,,
 ,DascaluA/hrapp,master,maven,,java8,,,,
 ,DashboardHub/PipelineDashboard,v0.11.9,,,java8,,,TRUE,Top-level build tool file is missing
-,DaspawnW/vault-crd,master,maven,,java8,,,,
+,DaspawnW/vault-crd,master,maven,,java11,,,,
 ,DataBiosphere/consent,develop,maven,,java8,,,,
 ,DataBiosphere/consent-ontology,develop,maven,,java8,,,,
 ,DataBiosphere/jade-data-repo,develop,,,java8,,,,
@@ -2130,7 +2130,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Deinonychus555/JHipsterMySQL2,master,maven,,java8,,,,
 ,Delta2Force/MCVmComputers,master,,,java8,,,,
 ,Demon95/JHipsterTest,master,maven,,java8,,,,
-,Dempsy/dempsy,master,maven,,java8,,,,
+,Dempsy/dempsy,master,maven,,java11,,,,
 ,DenDugin/Resume_project,master,maven,,java8,,,,
 ,DengSinkiang/sk-admin,master,maven,,java8,,,,
 ,DenissLarka/gnucash,master,maven,,java8,,,,
@@ -2143,13 +2143,13 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,DerYeger/Project_RBSG,master,,,java8,,,,
 ,DerYeger/destiny-api-explorer,master,,,java8,,,,
 ,DerYeger/komi,develop,,,java8,,,,
-,DerYeger/primeservice,master,,gradle,java8,,,,
+,DerYeger/primeservice,master,,gradle,java17,,,,
 ,DerYeger/r6-stats,master,,,java8,,,,
 ,DerYeger/stock-simulator,develop,,,java8,,,,
 ,DerekYRC/mini-spring,main,maven,,java8,,,,
 ,Derron210/amGenAsm,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,DesarrolloAntonio/FragmentTransactionExtended,master,,,java8,,,,
-,DeskChan/DeskChan,master,,,java8,,,,
+,DeskChan/DeskChan,master,,,java11,,,,
 ,Desperado24/apkreduce,master,,,java8,,,TRUE,Build uses Gradle 3.x
 ,Dev222-sys/DesiAustrilla,master,,,java8,,,,
 ,DevAnthony/jhipsterSampleApplication,master,maven,,java8,,,,
@@ -2158,7 +2158,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,DevNatan/inventory-framework,main,,,java8,,,,
 ,DevOpsHackathon2021/api-user-java,main,maven,,java8,,,,
 ,DevPSU/Attendance-Manager,master,,,java8,,,TRUE,Top-level build tool file is missing
-,Devan-Kerman/ARRP,master,,,java8,,,,
+,Devan-Kerman/ARRP,master,,,java17,,,,
 ,DevelopedLogic/CtrlAltBot,master,,,java8,,,,
 ,DeveloperCielo/API-3.0-Android,master,,gradle,java8,,,,
 ,DeveloperCielo/LIO-SDK-API-Integracao-Remota-v1-Java,master,,,java8,,,TRUE,Build uses Gradle 2.x
@@ -2312,7 +2312,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,DroidsOnRoids/Workcation,master,,,java8,,,,
 ,DroidsOnRoids/android-gradle-aosp-aapt-plugin,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,DroidsOnRoids/android-gradle-ui-test-plugin,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
-,DroidsOnRoids/jspoon,master,,,java8,,,,
+,DroidsOnRoids/jspoon,master,,,java8,,,TRUE,Gradle wrapper 4.4.1 is not supported
 ,Dropbox/AffectedModuleDetector,main,,,java8,,,,
 ,DrownCoder/EasyTextView,master,,,java8,,,,
 ,Dsiner/UIUtil,master,,,java8,,,,
@@ -2444,10 +2444,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Endoman123/hold-my-coffee,develop,,,java8,,,,
 ,Enea2201/poc-jh,master,maven,,java8,,,,
 ,EngineHub/CommandBook,master,,,java8,,,,
-,EngineHub/CommandHelper,master,maven,,java8,,,,
+,EngineHub/CommandHelper,master,maven,,java11,,,,
 ,EngineHub/CraftBook,master,,,java8,,,,
 ,EngineHub/Intake,master,,,java8,,,,
-,EngineHub/SquirrelID,master,,,java8,,,,
+,EngineHub/SquirrelID,master,,,java11,,,,
 ,EngineHub/WorldGuard,master,,,java8,,,,
 ,EngineerSu/Simple-RPC,master,maven,,java8,,,,
 ,Enigmaderockz/DeltaX-project,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -2492,9 +2492,9 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Ernstsen/LEGO-The-language,master,,,java8,,,,
 ,Ernstsen/LWE-Implementation,master,maven,,java8,,,,
 ,Ernstsen/StorkApp,master,,,java8,,,,
-,Erudika/para,master,maven,,java8,,,,
+,Erudika/para,master,maven,,java11,,,,
 ,Erudika/para-search-elasticsearch,master,maven,,java8,,,,
-,Erudika/scoold,master,maven,,java8,,,,
+,Erudika/scoold,master,maven,,java11,,,,
 ,Esalas92/spring-azure-function,main,maven,,java8,,,,
 ,Eselter/AA-Phenotype-Patcher,master,,,java8,,,,
 ,EsotericSoftware/kryo,master,maven,,java8,,,,
@@ -2566,7 +2566,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Etienne-io/MaterialDrawerTestApp,searchAsActivity,,,java8,,,,
 ,EtienneMiret/sass-gradle-plugin,master,,,java8,,,,
 ,EtiennePerot/fuse-jna,master,,gradle,java8,,,,
-,Eufranio/MagiBridge,api-7,,,java8,,,,
+,Eufranio/MagiBridge,api-7,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,EugeneHoran/Android-Material-SearchView,master,,,java8,,,,
 ,EugenePig/ik-analyzer-solr5,master,maven,,java8,,,,
 ,Everyone-s-delivery/BackEnd,master,maven,,java8,,,,
@@ -2597,7 +2597,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,F1-Manager/F1-Manager,master,maven,,java8,,,,
 ,F43nd1r/gradle-release,master,,,java8,,,,
 ,F43nd1r/gradlekeepass,master,,,java8,,,,
-,FAForever/faf-java-api,develop,,,java8,,,,
+,FAForever/faf-java-api,develop,,,java17,,,,
 ,FAMILIAR-project/VideoGen2,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,FAltamiranoZ/Whack-a-Mole,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,FCA69/devops,master,maven,,java8,,,,
@@ -2637,7 +2637,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Fabinout/monolithApplication,master,maven,,java8,,,,
 ,Fabric3/fabric3-sass,master,,,java8,,,,
 ,FabricMC/fabric-loader,master,,,java8,,,,
-,FabricMC/fabric-loom,dev/0.12,,,java8,,,,
+,FabricMC/fabric-loom,dev/0.12,,,java11,,,,
 ,FacePlusPlus/MegviiLicMgr-Android-SDK,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,Fadelis/grpcmock,master,maven,,java8,,,,
 ,Fadezed/concurrency,master,maven,,java8,,,,
@@ -2707,7 +2707,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,FaustVs/TaxiWizzProto,master,maven,,java8,,,,
 ,Faylixe/googlecodejam-client,master,maven,,java8,,,,
 ,Faylixe/marklet,master,maven,,java8,,,,
-,Fazecast/jSerialComm,master,,,java8,,,,
+,Fazecast/jSerialComm,master,,,java11,,,,
 ,Fear-Joy-Index/fear-joy-index-android-app,main,,,java8,,,,
 ,FeatureIDE/FeatureIDE,develop,maven,,java8,,,,
 ,Feavy/Pokemon-Discord,master,,,java8,,,,
@@ -2771,7 +2771,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,FirePub/jenkinsci-mber-plugin,master,maven,,java8,,,,
 ,FireRedDev/Infi,master,maven,,java8,,,,
 ,FireZenk/AudioWaves,develop,,,java8,,,,
-,FirebirdSQL/jaybird,master,,,java8,,,,
+,FirebirdSQL/jaybird,master,,,java17,,,,
 ,Firedamp/Rudeness,master,,,java8,,,,
 ,Firely-Pasha/k-shiki-sdk,master,,,java8,,,,
 ,First-Peoples-Cultural-Council/fv-web-ui,master,maven,,java8,,,,
@@ -2852,7 +2852,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Francis-FY/java-agent-demo,master,maven,,java8,,,,
 ,FrancisRoc/multisicanalyse,master,maven,,java8,,,,
 ,FranclisJunior/iFit,master,maven,,java8,,,,
-,FrangSierra/RxFirebase,master,,,java8,,,,
+,FrangSierra/RxFirebase,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,Frank-Mayer/minecraft-tasker,main,maven,,java8,,,,
 ,Frank-Zhu/AndroidRecyclerViewDemo,master,,,java8,,,,
 ,Frank-Zhu/AppCodeArchitecture,master,,,java8,,,,
@@ -2861,14 +2861,14 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,FrankBian/tomcat8.0-source-research,master,maven,,java8,,,,
 ,FrankerSun/netty-study-4.x,4.1,maven,,java8,,,,
 ,FrankieZhen/miaosha,master,maven,,java8,,,,
-,FrantisekGazo/Blade,master,,,java8,,,,
+,FrantisekGazo/Blade,master,,,java8,,,TRUE,Gradle wrapper 4.9 is not supported
 ,FrantisekGazo/JavassistHelper,master,,,java8,,,,
 ,Fraser123456/blog,master,maven,,java8,,,,
 ,Fraser123456/online-store,master,maven,,java8,,,,
 ,FredPi17/home-application-jhipster,master,maven,,java8,,,,
 ,FredPi17/sed-web,master,maven,,java8,,,,
 ,FreddyChen/CEventCenter,master,,,java8,,,,
-,FreddyChen/NettyChat,master,,,java8,,,,
+,FreddyChen/NettyChat,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,FreddyVilla94/FastoreApp,master,,,java8,,,,
 ,FrederickRider/AutoCompleteBubbleText,master,,gradle,java8,,,,
 ,Free-Software-for-Android/NTPSync,master,,,java8,,,,
@@ -2894,7 +2894,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,FrozenFreeFall/Android-tv-widget,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,FrpcCluster/frpc-Android,master,,,java8,,,,
 ,Fruzenshtein/spr-data,master,maven,,java8,,,,
-,Fuchs-David/Annotator,master,maven,,java8,,,,
+,Fuchs-David/Annotator,master,maven,,java17,,,,
 ,FudanNLP/fnlp,master,maven,,java8,,,,
 ,FudanSELab/train-ticket,master,maven,,java8,,,,
 ,Fueled/flowr,master,,,java8,,,,
@@ -2936,7 +2936,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,GTTo/dondereciclo,master,maven,,java8,,,,
 ,GWELL52/jhipster-sample-application,master,maven,,java8,,,,
 ,GWP-SMN/jhipsterSampleApplication,master,maven,,java8,,,,
-,GZYangKui/vertx-mall,master,maven,,java8,,,,
+,GZYangKui/vertx-mall,master,maven,,java11,,,,
 ,GaRyXiaoPh/shop,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,GabrielPerezMinik/Jdom,main,maven,,java8,,,,
 ,GabrielTK/MCRunGradle,master,,,java8,,,,
@@ -2971,7 +2971,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,GavinCT/SimpleLeakCanary,master,,,java8,,,,
 ,Gazetteer-Panda/JavaTestDemo,master,maven,,java8,,,,
 ,Gazmir/jhipsterSampleApplication,master,maven,,java8,,,,
-,GcsSloop/arc-seekbar,master,,,java8,,,,
+,GcsSloop/arc-seekbar,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,GcsSloop/diycode,master,,,java8,,,,
 ,GdinKing/HandWrite,master,,,java8,,,,
 ,GeekBugs/Android-SerialPort,master,,,java8,,,,
@@ -2984,7 +2984,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,GengTianHa0/SkillDemo,master,maven,,java8,,,,
 ,GenshenWang/SSM_HRMS,master,maven,,java8,,,,
 ,Genymobile/mirror,master,,,java8,,,,
-,Genymobile/scrcpy,master,,,java8,,,,
+,Genymobile/scrcpy,master,,,java11,,,,
 ,GeoDienstenCentrum/closure-compiler-maven-plugin,master,maven,,java8,,,,
 ,GeoKnow/LinkedGeoData,develop,,,java8,,,TRUE,Top-level build tool file is missing
 ,GeoLatte/geolatte-geom,master,maven,,java8,,,,
@@ -3014,7 +3014,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,GetuiLaboratory/getui-pushapi-java-demo,master,maven,,java8,,,,
 ,GeyserMC/Floodgate,master,,,java8,,,,
 ,GeyserMC/Geyser,master,maven,,java8,,,,
-,GeyserMC/GeyserConnect,master,maven,,java8,,,,
+,GeyserMC/GeyserConnect,master,maven,,java17,,,,
 ,GeyserMC/MCProtocolLib,master,maven,,java8,,,,
 ,GggEole/jhipster-sample-application,master,maven,,java8,,,,
 ,Ggoals/HonSulHonBab_admin,master,maven,,java8,,,,
@@ -3074,7 +3074,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Gliby/gaal-gradle,master,,,java8,,,,
 ,GlitchLib/glitch,master,,,java8,,,,
 ,Gliwson/blog,master,maven,,java8,,,,
-,Glorf/HarcSzyfry,master,,,java8,,,,
+,Glorf/HarcSzyfry,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,Glovo/gradle-versioning-plugin,master,,,java8,,,,
 ,GlowstoneMC/Glowstone,dev,,,java8,,,,
 ,GluuFederation/casa,master,maven,,java8,,,,
@@ -3220,7 +3220,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,GoogleContainerTools/jib,master,,,java8,,,,
 ,GoogleContainerTools/jib-extensions,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,GoogleContainerTools/minikube-build-tools-for-java,master,,,java8,,,TRUE,Top-level build tool file is missing
-,GoogleLLP/SuperMarket,master,maven,,java8,,,,
+,GoogleLLP/SuperMarket,master,maven,,java11,,,,
 ,Gopalmca/jhipster-sample-application,master,maven,,java8,,,,
 ,Gopalmca/jhipsterapp,master,maven,,java8,,,,
 ,GorkaUrzelai/reparationsSpring,master,maven,,java8,,,,
@@ -3278,7 +3278,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,GuoMinJim/PersonManage,master,maven,,java8,,,,
 ,Gutyn/camera2QRcodeReader,master,,,java8,,,,
 ,GwtMaterialDesign/gwt-material,master,maven,,java8,,,,
-,Gyv12345/yt4j,master,maven,,java8,,,,
+,Gyv12345/yt4j,master,maven,,java17,,,,
 ,H07000223/FlycoBanner_Master,master,,,java8,,,,
 ,H07000223/FlycoDialog_Master,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,H07000223/FlycoLabelView,master,,,java8,,,,
@@ -3356,7 +3356,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,HamzaMoummid/jhipsterSampleApplicationMonolithic,master,maven,,java8,,,,
 ,Han-YLun/SaaS_IHRM,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,HanPhan91/Web-Coffee-Management,main,,,java8,,,,
-,HanSolo/medusa,master,,,java8,,,,
+,HanSolo/medusa,master,,,java11,,,,
 ,HandyPantry/handy-pantry,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,HandyPantry/handy-pantry-wcos,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,Hankkin/BaiduGoingRefreshLayout,master,,,java8,,,,
@@ -3377,13 +3377,13 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Haringma/gmall-parent,master,maven,,java8,,,,
 ,Haringma/gmall-parent-d,master,maven,,java8,,,,
 ,Hariofspades/Dagger-2-Advanced,master,,,java8,,,,
-,Harish1997/svcepro,master,,,java8,,,,
+,Harish1997/svcepro,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,Harlber/Moose,master,,,java8,,,,
 ,Harleyoc1/TranslationSheet,main,,,java8,,,,
 ,Harshit008/CareerSolutionsBackend_V1.3,master,maven,,java8,,,,
 ,HarshitChhipa/jhipster-demo-application,master,maven,,java8,,,,
 ,HarshitKaushik/ideative-project,master,,,java8,,,TRUE,Top-level build tool file is missing
-,HarvardPL/formulog,master,maven,,java8,,,,
+,HarvardPL/formulog,master,maven,,java11,,,,
 ,HashDataInc/bireme,master,maven,,java8,,,,
 ,HaugrNet/cws,master,maven,,java8,,,,
 ,HaveBigern/MooseChips,master,maven,,java8,,,,
@@ -3631,7 +3631,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,IBM/knative-eventing-java-app,master,maven,,java8,,,,
 ,IBM/kv-utils,main,maven,,java8,,,,
 ,IBM/lagom-object-storage,master,maven,,java8,,,,
-,IBM/landmark,develop,maven,,java8,,,,
+,IBM/landmark,develop,maven,,java11,,,,
 ,IBM/liberty-outage-reporter,master,maven,,java8,,,,
 ,IBM/mdm-java-sdk,main,maven,,java8,,,,
 ,IBM/mdmce-environment-deployment-toolkit,master,maven,,java8,,,,
@@ -3652,7 +3652,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,IBM/project-util,master,maven,,java8,,,,
 ,IBM/qradar-monitor-device-events,master,maven,,java8,,,,
 ,IBM/ram-guards,main,,,java8,,,,
-,IBM/reactive-components,master,,,java8,,,,
+,IBM/reactive-components,master,,,java8,,,TRUE,Gradle wrapper 4.8 is not supported
 ,IBM/rules_extraction_from_healthcare_policy,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,IBM/scc-java-sdk,main,maven,,java8,,,,
 ,IBM/schematics-java-sdk,main,maven,,java8,,,,
@@ -3676,15 +3676,15 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,IBM/watson-data-api-clients,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,IBMStockTrader/.github,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,IBMStockTrader/account,master,maven,,java8,,,,
-,IBMStockTrader/broker,master,maven,,java8,,,,
+,IBMStockTrader/broker,master,maven,,java11,,,,
 ,IBMStockTrader/broker-query,master,maven,,java8,,,,
 ,IBMStockTrader/collector,master,maven,,java8,,,,
-,IBMStockTrader/looper,master,maven,,java8,,,,
+,IBMStockTrader/looper,master,maven,,java11,,,,
 ,IBMStockTrader/loyalty-level,master,maven,,java8,,,,
 ,IBMStockTrader/messaging,master,maven,,java8,,,,
 ,IBMStockTrader/notification-slack,master,maven,,java8,,,,
 ,IBMStockTrader/notification-twitter,master,maven,,java8,,,,
-,IBMStockTrader/portfolio,master,maven,,java8,,,,
+,IBMStockTrader/portfolio,master,maven,,java11,,,,
 ,IBMStockTrader/portfolio-spring,master,maven,,java8,,,,
 ,IBMStockTrader/stock-quote,master,maven,,java8,,,,
 ,IBMStockTrader/stock-quote-quarkus,master,maven,,java8,,,,
@@ -3712,13 +3712,13 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,IHTSDO/snomed-owl-toolkit,master,maven,,java8,,,,
 ,IHTSDO/snomed-query-service,master,maven,,java8,,,,
 ,IHTSDO/snomed-template-service,master,maven,,java8,,,,
-,IHTSDO/snowstorm,master,maven,,java8,,,,
+,IHTSDO/snowstorm,master,maven,,java11,,,,
 ,ILyaCyclone/lunch-voting,master,maven,,java8,,,,
 ,INCHEON-CHO/CRF_APP,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,INDExOS/media-for-mobile,master,,,java8,,,,
 ,INET-Complexity/housing-model,master,maven,,java8,,,,
 ,INRIA/hybridvis,master,,,java8,,,TRUE,Top-level build tool file is missing
-,INRIA/spoon,master,maven,,java8,,,,
+,INRIA/spoon,master,maven,,java11,,,,
 ,IOT-DSA/sdk-dslink-java,master,,,java8,,,,
 ,IQSS/dataverse,develop,maven,,java8,,,,
 ,IQSS/dataverse-client-java,master,,,java8,,,,
@@ -3881,7 +3881,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,IvoNet/docker-course,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,IvonaSoftware/ivona-speechcloud-sdk-java,master,maven,,java8,,,,
 ,IvorHu/RealStuff,master,,,java8,,,,
-,J0HNN7G/EpiSim,master,,,java8,,,,
+,J0HNN7G/EpiSim,master,,,java11,,,,
 ,JBEI/ice,trunk,maven,,java8,,,,
 ,JBO24/CyclingApp,master,maven,,java8,,,,
 ,JBossOutreachArchive/certificate-generator-server-archive,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -3919,7 +3919,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,JLLeitschuh/kotlin-scripting-jdk9,master,,,java8,,,,
 ,JLLeitschuh/ktlint-gradle,master,,,java8,,,,
 ,JLLeitschuh/moderne-test,main,,,java8,,,,
-,JLLeitschuh/pmd-kotlin,master,,,java8,,,,
+,JLLeitschuh/pmd-kotlin,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,JLLeitschuh/refactoring-interview-question,master,,,java8,,,,
 ,JLLeitschuh/springBootTesting,master,,,java8,,,,
 ,JLarky/jenkins-kato-plugin,master,maven,,java8,,,,
@@ -3927,14 +3927,14 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,JMPergar/AwesomeText,master,,,java8,,,,
 ,JMRI/JMRI,master,maven,,java11,,,,
 ,JNBourrat/jhipster-sample-application,master,maven,,java8,,,,
-,JNOSQL/demos,main,maven,,java8,,,,
+,JNOSQL/demos,main,maven,,java11,,,,
 ,JOML-CI/JOML,main,maven,,java8,,,,
 ,JOSM/josm,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,JPeter95/jhipster,master,maven,,java8,,,,
 ,JPlant-dev/wallet,master,,,java8,,,,
 ,JPressProjects/jpress,master,maven,,java8,,,,
 ,JR-10/Prueba1Jhispter,master,maven,,java8,,,,
-,JSQLParser/JSqlParser,master,,,java8,,,,
+,JSQLParser/JSqlParser,master,,,java11,,,,
 ,JSugey/PagoLineaCarrito,master,maven,,java8,,,,
 ,JSugey/blog,master,maven,,java8,,,,
 ,JTRedEye26/pocketBoyfriend,main,,,java8,,,TRUE,Top-level build tool file is missing
@@ -4033,7 +4033,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,JasonChene/Archer,master,maven,,java8,,,,
 ,JasonCrease/redgatesqlci,master,maven,,java8,,,,
 ,JasonGaoH/XTabLayout,master,,,java8,,,,
-,JasonHzx/DragSortlist,master,,,java8,,,,
+,JasonHzx/DragSortlist,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,JasonPer/SignInServer,master,maven,,java8,,,,
 ,JasonPer/exam-backstage,master,maven,,java8,,,,
 ,JasonQS/Anti-recall,master,,,java8,,,,
@@ -4108,7 +4108,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Jefferson-Henrique/GetOldTweets-java,master,maven,,java8,,,,
 ,Jeffrey-deng/imcoder-blog,master,maven,,java8,,,,
 ,JehoiadaChan/Spring-SpringMVC-MyBatis,master,maven,,java8,,,,
-,Jeickt/bikescanoas,master,maven,,java8,,,,
+,Jeickt/bikescanoas,master,maven,,java11,,,,
 ,Jelmerro/UniCam,master,maven,,java8,,,,
 ,JemliFathi/test,master,maven,,java8,,,,
 ,JeremyLiao/FastSharedPreferences,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -4130,7 +4130,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,JessYanCoding/RxErrorHandler,2.x,,,java8,,,,
 ,JesusFreke/smali,master,,,java8,,,,
 ,JetBrains-Research/GraphVarMiner,main,,,java8,,,TRUE,Error: Could not find or load main class org.gradle.wrapper.GradleWrapperMain (gradlew present but wrapper jar missing)
-,JetBrains-Research/IRen,main,,,java8,,,,
+,JetBrains-Research/IRen,main,,,java11,,,,
 ,JetBrains-Research/IntelliJDeodorant,master,,,java8,,,,
 ,JetBrains-Research/MoveMethodGenerator,master,,,java8,,,,
 ,JetBrains-Research/RefactorInsight,master,,,java8,,,,
@@ -4143,8 +4143,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,JetBrains-Research/kinference-primitives,master,,,java8,,,,
 ,JetBrains-Research/kotlinRMiner,master,,,java8,,,,
 ,JetBrains-Research/topias,master,,,java8,,,,
-,JetBrains/Arend,master,,,java11,,,,
-,JetBrains/Grammar-Kit,master,,,java8,,,,
+,JetBrains/Arend,master,,,java17,,,,
+,JetBrains/Grammar-Kit,master,,,java11,,,,
 ,JetBrains/TeamCity.SonarQubePlugin,master,maven,,java8,,,,
 ,JetBrains/adt-tools-base,master,,gradle,java8,,,,
 ,JetBrains/andel,master,maven,,java8,,,,
@@ -4167,7 +4167,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,JetBrains/gradle-ruby-envs,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,JetBrains/hackathon19_deskovery,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,JetBrains/idea-gradle-jps-build-app,master,,,java8,,,,
-,JetBrains/ideavim,master,,,java8,,,,
+,JetBrains/ideavim,master,,,java11,,,,
 ,JetBrains/ij_tutorial_gradle,master,,,java8,,,,
 ,JetBrains/intellij-coverage,master,,,java8,,,,
 ,JetBrains/intellij-deps-asm,master,,gradle,java8,,,,
@@ -4261,7 +4261,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Jett59/itgStuff,master,maven,,java8,,,,
 ,Jett59/language01,master,maven,,java8,,,,
 ,Jett59/musicDesign,master,maven,,java8,,,,
-,Jett59/slogger,master,maven,,java8,,,,
+,Jett59/slogger,master,maven,,java11,,,,
 ,Jett59/starcarv,master,maven,,java8,,,,
 ,Jett59/werekitten,master,maven,,java8,,,,
 ,Jett59/werekitten-server,master,maven,,java8,,,,
@@ -4269,7 +4269,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Jhuster/AudioDemo,master,,,java8,,,,
 ,Jhuster/ImageCropper,master,,,java8,,,,
 ,Jhuster/JNote,master,,,java8,,,,
-,Jhvictor4/gradle-plugins,main,,,java8,,,,
+,Jhvictor4/gradle-plugins,main,,,java11,,,,
 ,Jiaenong/GrabNGo,master,,,java8,,,,
 ,Jianbo-Zhu/shiftwork,master,maven,,java8,,,,
 ,Jiaru0314/cloud2020,master,maven,,java8,,,,
@@ -4306,7 +4306,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,JodaOrg/joda-beans-integrate,master,maven,,java8,,,,
 ,JodaOrg/joda-beans-maven-plugin,master,maven,,java8,,,,
 ,JodaOrg/joda-collect,master,maven,,java8,,,,
-,JodaOrg/joda-convert,main,maven,,java8,,,,
+,JodaOrg/joda-convert,main,maven,,java11,,,,
 ,JodaOrg/joda-money,master,maven,,java8,,,,
 ,JodaOrg/joda-time,master,maven,,java8,,,,
 ,JodaOrg/joda-time-hibernate,master,maven,,java8,,,,
@@ -4319,7 +4319,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Joguny2/Expense-Reimbursement-System,main,,,java8,,,,
 ,JoherYu/social-network-SSM-Vue,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,JohnAkim10/RollyNew,master,,,java8,,,,
-,JohnDeere/work-tracker,master,maven,,java8,,,,
+,JohnDeere/work-tracker,master,maven,,java11,,,,
 ,JohnMurray/etcd4j-lock,master,maven,,java8,,,,
 ,JohnPersano/SuperToasts,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,JohnPossible/jhipster-sample-application,master,maven,,java8,,,,
@@ -4440,7 +4440,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,KB5201314/ConfessTalkKiller,master,,,java8,,,,
 ,KBNLresearch/europeananp-ner,master,maven,,java8,,,,
 ,KDE/brooklyn,master,maven,,java8,,,,
-,KDE/kdeconnect-android,master,,,java8,,,,
+,KDE/kdeconnect-android,master,,,java11,,,,
 ,KDE/wikitolearn-course-midtier,master,maven,,java8,,,,
 ,KDE/wikitolearn-pwa-gateway,master,maven,,java8,,,,
 ,KDamir/izzitour,master,maven,,java8,,,,
@@ -4456,7 +4456,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,KainosSoftwareLtd/sample-dropwizard-service,master,,gradle,java8,,,,
 ,Kaitis/WorkSpace,master,maven,,java8,,,,
 ,KajanM/DSVL,master,,,java8,,,TRUE,Top-level build tool file is missing
-,KajanM/iworkflows,master,,,java8,,,,
+,KajanM/iworkflows,master,,,java8,,,TRUE,Gradle wrapper 4.8.1 is not supported
 ,KajuszZ/PickMeModelV1,master,maven,,java8,,,,
 ,KalebKE/FSensor,master,,,java8,,,,
 ,KalebKE/GyroscopeExplorer,master,,,java8,,,,
@@ -4497,13 +4497,13 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,KayLerch/alexa-skills-kit-tellask-java,master,maven,,java8,,,,
 ,KayLerch/alexa-utterance-generator,master,maven,,java8,,,,
 ,Kcastro94/Angular,master,maven,,java8,,,,
-,KeNanStar/SakuApng,master,,,java8,,,,
+,KeNanStar/SakuApng,master,,,java8,,,TRUE,Gradle wrapper 4.5 is not supported
 ,KePeng1019/SmartPaperScan,master,,,java8,,,,
 ,KedarCharkha08/ScheduleIt---JAVA,master,,,java8,,,,
 ,KeeganSullivan77/streamerdemo,master,maven,,java8,,,,
 ,KeenWarrior/AdMob,master,,,java8,,,,
 ,KeenWarrior/bill-android,master,,,java8,,,,
-,KeenWarrior/bill-server,master,,,java8,,,,
+,KeenWarrior/bill-server,master,,,java8,,,TRUE,Gradle wrapper 4.5.1 is not supported
 ,KeenWarrior/game-dev,master,,,java8,,,,
 ,KeenWarrior/sumper-jumper,master,,,java8,,,,
 ,KeenWarrior/vertx-gradle-simple,master,,,java8,,,,
@@ -4514,7 +4514,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,KeepSafe/ReLinker,master,,,java8,,,,
 ,KeepSafe/TapTargetView,master,,,java8,,,,
 ,KeepSafe/dexcount-gradle-plugin,master,,,java11,,,,
-,Keksnet/JAGIL,master,maven,,java8,,,,
+,Keksnet/JAGIL,master,maven,,java11,,,,
 ,Ken-W-P-Huang/lazyfish,master,,gradle,java8,,,,
 ,Keneral/aetwo,X556N,,,java8,,,TRUE,Top-level build tool file is missing
 ,KengoTODA/findbugs-slf4j,master,maven,,java8,,,,
@@ -4582,8 +4582,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Klemek/SortedGallery,master,maven,,java8,,,,
 ,Klemek/Villes,master,maven,,java8,,,,
 ,KnisterPeter/jreact,master,maven,,java8,,,,
-,Knorrke/MazeRunner,main,maven,,java8,,,,
-,Knorrke/socialbotnet,master,maven,,java8,,,,
+,Knorrke/MazeRunner,main,maven,,java11,,,,
+,Knorrke/socialbotnet,master,maven,,java11,,,,
 ,Knotworking/Numbers,master,,,java8,,,,
 ,KoMinkyu/teaspoon,master,,,java8,,,,
 ,KoalaQ/dubbo-cp,master,maven,,java8,,,,
@@ -4614,8 +4614,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,KostyaSha/github-integration-plugin,master,maven,,java8,,,,
 ,KostyaSha/yet-another-docker-plugin,master,maven,,java8,,,,
 ,Kotlin/binary-compatibility-validator,master,,,java8,,,,
-,Kotlin/dataframe,master,,,java8,,,,
-,Kotlin/kotlin-benchmarks,master,maven,,java8,,,,
+,Kotlin/dataframe,master,,,java11,,,,
+,Kotlin/kotlin-benchmarks,master,maven,,java17,,,,
 ,Kotlin/kotlin-examples,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,Kotlin/kotlin-jupyter,master,,,java8,,,,
 ,Kotlin/kotlin-libs-publisher,master,,,java8,,,,
@@ -4632,7 +4632,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Krocodial/AcmePass,master,maven,,java8,,,,
 ,KrystianKorbecki/spring-gym-web-service,main,maven,,java8,,,,
 ,KrystianZakrys/Spring-Workshop,master,maven,,java8,,,,
-,KsaneK/JarEditor,master,maven,,java8,,,,
+,KsaneK/JarEditor,master,maven,,java11,,,,
 ,KshitijMJadhav/EAssess,master,,,java8,,,,
 ,Ktailor34/authorIdentifier,master,maven,,java8,,,,
 ,KualiCo/rice,11,maven,,java8,,,,
@@ -4713,7 +4713,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,LambdaXiao/StockChart-MPAndroidChart,master,,,java8,,,,
 ,Lance-Drane/BugTrackerJHipster,master,maven,,java8,,,,
 ,LanceaKing/logging-log4j2-vulnerable,vulnerable,maven,,java8,,,,
-,LanderlYoung/kproto,master,,,java8,,,,
+,LanderlYoung/kproto,master,,,java8,,,TRUE,Gradle wrapper 4.7 is not supported
 ,Landsbokasafn/deduplicator,master,maven,,java8,,,,
 ,Lantern-Cloud-Services/Demo-Function-Java-mvn-ghcicd,master,maven,,java8,,,,
 ,LapisBlue/MethodRemapper,master,,,java8,,,TRUE,Build uses Gradle 2.x
@@ -4757,7 +4757,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,LennardZuendorf/project_habitusWIP,main,,,java8,,,,
 ,LeonDevLifeLog/GestureLockView,master,,,java8,,,,
 ,LeonHartley/Coerce,master,maven,,java8,,,,
-,LeonLeonPotato/skeet-gui,master,,,java8,,,,
+,LeonLeonPotato/skeet-gui,master,,,java8,,,TRUE,Gradle wrapper 4.9 is not supported
 ,LeonTG/TeamHealth,master,maven,,java8,,,,
 ,LeonardoBezerraBispo/function-tools,main,maven,,java8,,,,
 ,LeonardoCardoso/Android-Link-Preview,master,,,java8,,,,
@@ -4835,7 +4835,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Lincoln-Masetla/VideoStore,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,LineChen/FlickerProgressBar,master,,,java8,,,,
 ,LineCutFeng/PlayPicdio,master,,,java8,,,,
-,LineG/Sonia390,master,,,java8,,,,
+,LineG/Sonia390,master,,,java8,,,TRUE,Gradle wrapper 4.5.1 is not supported
 ,LingWeiTechnology/Youxue,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,LingWeiTechnology/myAnguar5Application,master,maven,,java8,,,,
 ,Linggify/CraftMiner,master,,,java8,,,,
@@ -5004,7 +5004,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,MZCretin/AutoUpdateProject,master,,,java8,,,,
 ,MZCretin/ExpandableTextView,master,,,java8,,,,
 ,MZCretin/WifiTransfer-master,master,,,java8,,,,
-,MaMaKow/ApothekenArchiv,main,maven,,java8,,,,
+,MaMaKow/ApothekenArchiv,main,maven,,java17,,,,
 ,MaShantao/tomcat_original,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,MaVvvv/spring-cloud,master,maven,,java8,,,,
 ,MaWenBo01/focus,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -5229,7 +5229,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Meetic/Shuffle,master,,,java8,,,,
 ,MegaMek/megamek,master,,,java8,,,,
 ,MegaMek/megameklab,master,,,java8,,,,
-,MegaMek/mekhq,master,,,java8,,,,
+,MegaMek/mekhq,master,,,java11,,,,
 ,MegatronKing/NetBare,master,,,java8,,,,
 ,MegatronKing/StringFog,master,,,java8,,,,
 ,MeghaBambra/android-material-travellist,master,,,java8,,,,
@@ -5237,7 +5237,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Meiqia/MeiqiaSDK-Android,master,,,java8,,,,
 ,Meituan-Dianping/Leaf,master,maven,,java8,,,,
 ,Meituan-Dianping/Robust,master,,,java8,,,TRUE,Build uses Gradle 2.x
-,Meituan-Dianping/Shield,master,,,java8,,,,
+,Meituan-Dianping/Shield,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,Meituan-Dianping/groupmeal-java-sdk,master,maven,,java8,,,,
 ,Meituan-Dianping/lyrebird-java-client,master,maven,,java8,,,,
 ,Meituan-Dianping/octo-portal,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -5252,7 +5252,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Memegle/memegle,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,MemoRyAxis/Test,master,maven,,java8,,,,
 ,Mengman/smart-healthcare,master,maven,,java8,,,,
-,MenoData/Time4J,master,maven,,java8,,,,
+,MenoData/Time4J,master,maven,,java11,,,,
 ,MentorQuesta/questa-vrm,master,maven,,java8,,,,
 ,Meowcolm024/MCTestMod,master,,,java8,,,,
 ,Mercateo/factcast,master,maven,,java8,,,,
@@ -5305,7 +5305,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Mijeca2/jhipster-MedicalApp,master,maven,,java8,,,,
 ,Mijeca2/jhipster-sample-application,master,maven,,java8,,,,
 ,Mik317/cwe-643,master,,,java8,,,,
-,Mikbac/Movie-selector,master,maven,,java8,,,,
+,Mikbac/Movie-selector,master,maven,,java11,,,,
 ,Mikbac/Repository-search-engine,master,maven,,java8,,,,
 ,Mikbac/Salary-Calculator,master,maven,,java8,,,,
 ,Mike-bel/MDStudySamples,master,,,java8,,,,
@@ -5416,7 +5416,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,MoizAli/fcmserver,master,maven,,java8,,,,
 ,MojamojaK/WASA-GhostLite,master,,,java8,,,,
 ,Mojang/AccountsClient,master,,gradle,java8,,,,
-,Mojang/DataFixerUpper,master,,,java8,,,,
+,Mojang/DataFixerUpper,master,,,java17,,,,
 ,Mojang/LegacyLauncher,master,,,java8,,,,
 ,Mojang/brigadier,master,,,java8,,,,
 ,MokraneKadri/jhipsterSampleApplication,master,maven,,java8,,,,
@@ -5496,7 +5496,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,MrExplode/ltc4j,master,,,java8,,,,
 ,MrFuFuFu/ClearEditText,master,,,java8,,,,
 ,MrGaoGang/luckly_popup_window,master,,,java8,,,,
-,MrJake222/AUNIS,master,,,java8,,,,
+,MrJake222/AUNIS,master,,,java8,,,TRUE,Gradle wrapper 4.8.1 is not supported
 ,MrKinau/FishingBot,main,maven,,java8,,,,
 ,MrMati/LifeGame,master,,,java8,,,,
 ,MrMaxx/gungungun,master,maven,,java8,,,,
@@ -5562,7 +5562,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,NAPOSCA/pantryplus,master,,,java8,,,,
 ,NASA-AMMOS/aerie,develop,,,java8,,,,
 ,NASAWorldWind/WorldWindAndroid,develop,,,java8,,,,
-,NCI-Agency/anet,main,,,java8,,,,
+,NCI-Agency/anet,main,,,java11,,,,
 ,NCZkevin/java_schoolproject,master,maven,,java8,,,,
 ,NDSLib/NDSL-Game,master,,,java8,,,,
 ,NEONKID/Spring-OAuthExample,master,,,java8,,,,
@@ -5583,7 +5583,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,NLPchina/elasticsearch-sql,master,maven,,java8,,,,
 ,NLPchina/nlp-lang,master,maven,,java8,,,,
 ,NOVA-Team/NOVA-Monorepo,master,,,java8,,,,
-,NSITonline/NSIT-Connect,master,,,java8,,,,
+,NSITonline/NSIT-Connect,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,NTNU-IHB/FMI4j,master,,,java8,,,,
 ,NTNU-IHB/sspgen,master,,,java8,,,,
 ,NTTDATA-EMEA/cinnamon,master,maven,,java8,,,,
@@ -5727,7 +5727,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Netflix/gradle-template,master,,,java8,,,,
 ,Netflix/hollow,master,,,java8,com.netflix.eureka.Style,,,
 ,Netflix/hollow-reference-implementation,master,,,java8,,,TRUE,Build uses Gradle 3.x
-,Netflix/iceberg,master,,,java8,,,,
+,Netflix/iceberg,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,Netflix/karyon,master,,,java8,,,,
 ,Netflix/mantis,master,,,java8,,,,
 ,Netflix/mantis-api,master,,,java8,,,,
@@ -5825,7 +5825,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Nincodedo/Ninbot,main,maven,,java8,,,,
 ,NineHite/Blog,master,maven,,java8,,,,
 ,Ninja-Squad/DbSetup,master,,,java8,,,,
-,Ninjeneer/ftp-scanner,master,maven,,java8,,,,
+,Ninjeneer/ftp-scanner,master,maven,,java17,,,,
 ,Nipuream/NRecyclerView,master,,,java8,,,,
 ,NiraParikh/ZipSocial,master,maven,,java8,,,,
 ,Nirash10qbit/campus_project,main,,,java8,,,,
@@ -5889,7 +5889,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Novartis/YADA,master,maven,,java8,,,,
 ,Novartis/ontobrowser,master,maven,,java8,,,,
 ,NovatecConsulting/JMeter-InfluxDB-Writer,master,,,java8,,,,
-,Novetta/CLAVIN,master,maven,,java8,,,,
+,Novetta/CLAVIN,master,maven,,java17,,,,
 ,Nsb83/JobTrack,master,maven,,java8,,,,
 ,Ntipa/ntipa-mashup,master,maven,,java8,,,,
 ,Ntipa/ntipa-presenze,master,maven,,java8,,,,
@@ -6060,13 +6060,13 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,OpenAPITools/openapi-petstore,master,maven,,java8,,,,
 ,OpenAPITools/openapi-style-validator,master,,,java8,,,,
 ,OpenAS2/OpenAs2App,master,maven,,java8,,,,
-,OpenArchitex/OpenLearnr,develop,maven,,java8,,,,
+,OpenArchitex/OpenLearnr,develop,maven,,java11,,,,
 ,OpenBD/openbd-core,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,OpenBW/BWAPI4J,develop,,,java8,,,,
 ,OpenCCG/openccg,master,maven,,java8,,,,
 ,OpenChaiSpark/OCspark,master,maven,,java8,,,,
 ,OpenClinica/OpenClinica,master,maven,,java8,,,,
-,OpenConext/Mujina,master,maven,,java8,,,,
+,OpenConext/Mujina,master,maven,,java11,,,,
 ,OpenConext/OpenConext-oidcng,master,maven,,java8,,,,
 ,OpenCubicChunks/CubicChunks,MC_1.12,,,java8,,,,
 ,OpenCubicChunks/CubicChunksConverter,master,,,java8,,,,
@@ -6130,7 +6130,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,OpenTSDB/asyncbigtable,master,maven,,java8,,,,
 ,OpenTSDB/opentsdb-elasticsearch,master,maven,,java8,,,,
 ,OpenTSDB/opentsdb-rpc-kafka,master,maven,,java8,,,,
-,OpenVidu/openvidu,master,maven,,java8,,,,
+,OpenVidu/openvidu,master,maven,,java11,,,,
 ,OpenVidu/openvidu-loadtest,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,OpenVidu/openvidu-tutorials,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,OpenWiseSolutions/openhub-framework,develop,maven,,java8,,,,
@@ -6230,7 +6230,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Pandemonium1986/pic-demo,master,maven,,java8,,,,
 ,PandoCloud/pando-android-sdk,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,Pangaj/RedisInJava,master,,,java8,,,TRUE,Top-level build tool file is missing
-,Panlf/springboot-learn,master,,gradle,java8,,,,
+,Panlf/springboot-learn,master,,gradle,java11,,,,
 ,Panlf/springboot-task-scheduled,master,maven,,java8,,,,
 ,PanyukovNN/life-manager,master,,,java8,,,,
 ,PaoloRotolo/AppIntro,master,,,java8,,,,
@@ -6332,7 +6332,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,PhantomThief/thrift-pool-client,master,maven,,java8,,,,
 ,PhantomThief/zkconfig-resources,master,maven,,java8,,,,
 ,PhantomThief/zknotify-cache,master,maven,,java8,,,,
-,PharmGKB/PharmCAT,development,,,java8,,,,
+,PharmGKB/PharmCAT,development,,,java17,,,,
 ,PhilJay/MPAndroidChart,master,,,java8,,,,
 ,PhilJay/MPAndroidChart-Realm,master,,,java8,,,,
 ,PhilipDeegan/org.kul,master,maven,,java8,,,,
@@ -6487,7 +6487,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Puneethkumarck/SpringProjects_Jhipster,master,maven,,java8,,,,
 ,Punit42000/LR,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,PurKot/busRoutePlanner-Java,master,,,java8,,,TRUE,Top-level build tool file is missing
-,PureWriter/ToastCompat,master,,,java8,,,,
+,PureWriter/ToastCompat,master,,,java8,,,TRUE,Gradle wrapper 4.7 is not supported
 ,PureWriter/about-page,master,,,java8,,,,
 ,PureWriter/desktop,master,,,java8,,,,
 ,PurelyApplied/gradle-jar-checks-plugin,master,,gradle,java8,,,,
@@ -6509,7 +6509,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Qatja/qatja-android,master,,,java8,,,,
 ,Qbian61/forum-java,main,maven,,java8,,,,
 ,Qi4j/qi4j-sdk,develop,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
-,Qiang3570/LiveLayout,master,,,java8,,,,
+,Qiang3570/LiveLayout,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,QiangJinWang/freemaker_test,main,maven,,java8,,,,
 ,Qianmeng2000/Chem-CS-125,master,,,java8,,,,
 ,QianmiOpen/dubbo-remoting-netty4,master,maven,,java8,,,,
@@ -6557,7 +6557,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ROMVoid95/ReadOnlyGradle,master,,,java8,,,,
 ,RPBTwisted/AIDB-Part-C,master,maven,,java8,,,,
 ,RPKennethPoh/myModules,master,,,java8,,,,
-,RPTools/maptool,develop,,,java8,,,,
+,RPTools/maptool,develop,,,java11,,,,
 ,RRanjitha/MyFirstAppJhipster,master,maven,,java8,,,,
 ,RS-CoderStuff/SilentReaction,master,maven,,java8,,,,
 ,RUB-NDS/BurpSSOExtension,master,maven,,java8,,,,
@@ -6579,7 +6579,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,RafaelBarbosa3A/ProjetoParaTeste,master,maven,,java8,,,,
 ,RagavanRevature/Spring-Security-SAML,v1,,,java8,,,,
 ,RaghAkram/E-Help,master,,,java8,,,,
-,Rahmalou/stb20-service,master,maven,,java8,,,,
+,Rahmalou/stb20-service,master,maven,,java11,,,,
 ,RahulJanagouda/StatusStories,master,,,java8,,,,
 ,Rahulkhinchi03/checkstyle-testing-lgtm,master,maven,,java8,,,,
 ,RaiMan/SikuliX-2014,develop,maven,,java8,,,,
@@ -6691,7 +6691,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Relucent/yyl_example,master,maven,,java8,,,,
 ,RemiNV/CalendarMute,master,,,java8,,,,
 ,RemyLeBeillan/jhipster-sample-application,master,maven,,java8,,,,
-,RenardFute/SCALU,main,maven,,java8,,,,
+,RenardFute/SCALU,main,maven,,java11,,,,
 ,RenatoFarofa/BestMeal,master,maven,,java8,,,,
 ,RenuTiwari1401/Encryption,master,,,java8,,,,
 ,RepreZen/KaiZen-OpenAPI-Editor,master,maven,,java8,,,,
@@ -6725,7 +6725,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,RichelleSWENG/HailHydra,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,RickyYu/Nfc-Android,master,,,java8,,,,
 ,Riddler454/jhipster,master,maven,,java8,,,,
-,RileyManda/GSAuto,master,,,java8,,,,
+,RileyManda/GSAuto,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,RileyManda/KiranaVendors,master,,,java8,,,,
 ,RileyManda/LittleRobot,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,RipMeApp/ripme,master,,,java8,,,,
@@ -6763,8 +6763,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Rogiel/l2jserver2,master,maven,,java8,,,,
 ,Rogiel/torrent4j,master,maven,,java8,,,,
 ,RohanNagar/dropwizard-template,master,maven,,java8,,,,
-,RohanNagar/lightning,master,maven,,java8,,,,
-,RohanNagar/thunder,master,maven,,java8,,,,
+,RohanNagar/lightning,master,maven,,java17,,,,
+,RohanNagar/thunder,master,maven,,java11,,,,
 ,RohitAwate/Everest,master,maven,,java8,,,,
 ,Rohithkakarla/Server-Connectivity,master,maven,,java8,,,,
 ,Rohitjoshi9023/KBC--Kaun-Banega-Crorepati,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -6829,7 +6829,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,RurioLuca/QrCardParsing,master,,,java8,,,,
 ,Rushane24/CryptoProject,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,RushikeshKamewar/PrivacyDashboard,main,,,java8,,,,
-,Ruskab/agrimManager,develop,maven,,java8,,,,
+,Ruskab/agrimManager,develop,maven,,java11,,,,
 ,RuslanIsniuk/Expenses-Management-Application,master,maven,,java8,,,,
 ,RussianPrussian/gradle-docker-compose-plugin,master,,,java8,,,,
 ,RustDT/RustDT,master,maven,,java8,,,,
@@ -6838,10 +6838,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,RuthlessImagineers/FeatureCollector,master,,,java8,,,,
 ,RuturajSutar/GCEKarad_Aavishkar_2020_Online_Event_Registration_Android_Application,master,,,java8,,,,
 ,RuturajSutar/Online_Chatting_Android_Application_Like_WhatsApp,master,,,java8,,,,
-,RxViper/RxViper,1.x,,,java8,,,,
+,RxViper/RxViper,1.x,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,Ryan-Shz/FastWebView,master,,,java8,,,,
 ,Rydiik/Aion-Server-4.7,master,,,java8,,,TRUE,Top-level build tool file is missing
-,RyuzakiKK/NoteCrypt,master,,,java8,,,,
+,RyuzakiKK/NoteCrypt,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,RyzeUserName/dubbo,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,S-Cool/Hexlett,master,maven,,java8,,,,
 ,S64/gradle-dependencies-preloader-plugin,master,,,java8,,,,
@@ -6893,7 +6893,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,SAP/jcomigrationhelperplugin,master,maven,,java8,,,,
 ,SAP/olingo-jpa-processor-v4,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,SAP/scimono,master,maven,,java8,,,,
-,SBDPlugins/V10Lift,master,maven,,java8,,,,
+,SBDPlugins/V10Lift,master,maven,,java11,,,,
 ,SBhojane/jhipsterSampleApplication,master,maven,,java8,,,,
 ,SCADA-LTS/Scada-LTS,develop,,gradle,java11,,,,
 ,SCAUComputerClassOneEEE/room-live,master,maven,,java8,,,,
@@ -6980,7 +6980,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,SalomonBrys/gradle-sass,master,,,java8,,,,
 ,SalomonBrys/kotlin-js-npm-bundle,master,,,java8,,,,
 ,Salvador2198/xanatProject,master,,,java8,,,,
-,SamChou19815/sampl,master,,,java8,,,,
+,SamChou19815/sampl,master,,,java8,,,TRUE,Gradle wrapper 4.8 is not supported
 ,SamThompson/BubbleActions,master,,,java8,,,,
 ,SamYStudiO/flair-gradle-plugin,master,,,java8,,,TRUE,Build uses Gradle 3.x
 ,Samarynin/ECommerce,master,,,java8,,,,
@@ -7072,7 +7072,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Sebastian1984/tika,master,maven,,java8,,,,
 ,SebastianRosenberg/DDS-TPANUAL,entrega.8,maven,,java8,,,,
 ,SebiiToader/uProcessorsProject,master,,,java8,,,,
-,Sebottenhof99/BACleanF,master,maven,,java8,,,,
+,Sebottenhof99/BACleanF,master,maven,,java11,,,,
 ,Sebottenhof99/BugDestroyer2Alter,master,maven,,java8,,,,
 ,Sebottenhof99/BugsDestroyer,master,maven,,java8,,,,
 ,SecUSo/privacy-friendly-netmonitor,master,,,java8,,,,
@@ -7099,10 +7099,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Semestre5/AMT_Projet,main,maven,,java8,,,,
 ,Semmle/lgtm-jira-addon,master,maven,,java8,,,,
 ,Sen1019/jhipsterTrial,master,maven,,java8,,,,
-,SenhLinsh/LshUnitTest,master,,,java8,,,,
+,SenhLinsh/LshUnitTest,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,SenhLinsh/Utils-Everywhere,master,,,java8,,,,
 ,Seniru/TFM-My-Tribe,master,maven,,java8,,,,
-,Seniru/WPM-Checker,master,maven,,java8,,,,
+,Seniru/WPM-Checker,master,maven,,java17,,,,
 ,SenorPez/glowing-potato,master,,,java8,,,,
 ,SensingKit/SensingKit-Android,master,,,java8,,,,
 ,SensorsINI/jaer,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -7350,7 +7350,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,SonarQubeCommunity/sonar-scm-stats,master,maven,,java8,,,,
 ,SonarQubeCommunity/sonar-widget-lab,master,maven,,java8,,,,
 ,SonarSource/SonarJS,master,maven,,java8,,,,
-,SonarSource/sonar-dotnet,master,maven,,java8,,,,
+,SonarSource/sonar-dotnet,master,maven,,java11,,,,
 ,SonarSource/sonar-java,master,maven,,java8,,,,
 ,SonarSource/sonar-ldap,master,maven,,java8,,,,
 ,SonarSource/sonar-php,master,maven,,java8,,,,
@@ -7393,14 +7393,14 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,SourceHot/spring-framework-read,source-hot-5.2.3,,,java8,,,,
 ,SourceLabOrg/kafka-webview,master,maven,,java8,,,,
 ,SourceStudyNotes/Tomcat8,master,maven,,java8,,,,
-,SourceWriters/vCompat,release,maven,,java8,,,,
+,SourceWriters/vCompat,release,maven,,java11,,,,
 ,Sovan25/master,master,maven,,java8,,,,
 ,SpaceBurrito-XYZ/ExplodeCmd,master,,,java8,,,,
 ,SpacialCircumstances/gradle-cucumber-reporting,master,,,java8,,,,
 ,SpaiR/imgui-java,main,,,java8,,,,
 ,SpareBank1/Troxy,master,maven,,java8,,,,
 ,SparkPost/java-sparkpost,master,maven,,java8,,,,
-,Sparker0i/Weather,master,,,java8,,,,
+,Sparker0i/Weather,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,Sparkobbable/ISBNValidation-Function,master,maven,,java8,,,,
 ,SpartanRefactoring/fluent.ly,master,maven,,java8,,,,
 ,SpartanRefactoring/spartan,master,maven,,java8,,,,
@@ -7418,7 +7418,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,SpiderLabs/burplay,master,maven,,java8,,,,
 ,Spigot-MSPL/iron,master,,,java8,,,,
 ,SpigotMC/BungeeCord,master,maven,,java8,,,,
-,SpikeKing/TestAppBar,master,,,java8,,,,
+,SpikeKing/TestAppBar,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,SpikeKing/TestCoordinatorLayout,master,,,java8,,,,
 ,Spikot/MangroveGradle,master,,,java8,,,,
 ,Spikot/SpikotGradle,master,,,java8,,,,
@@ -7494,7 +7494,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,StepanOrt/worktimetracker,master,maven,,java8,,,,
 ,Stephcraft/Project-16x16,master,maven,,java8,,,,
 ,Stericson/RootShell,master,,,java8,,,,
-,Stericson/RootTools,master,,,java8,,,,
+,Stericson/RootTools,master,,,java8,,,TRUE,Gradle wrapper 4.8 is not supported
 ,SteveBizimungu/Istic,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,StevenBoscarine/JavaAsciidocWrapper,master,maven,,java8,,,,
 ,StevenByle/Android-Material-Themes-Demo,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -7607,7 +7607,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,T45K/jgitTrial,master,,,java8,,,,
 ,T45K/kube-trial,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,T45K/library-trials,master,,,java8,,,,
-,T45K/lifegame-ver2,master,,,java8,,,,
+,T45K/lifegame-ver2,master,,,java8,,,TRUE,Gradle wrapper 4.8.1 is not supported
 ,T45K/spring-spock-trial,master,,,java8,,,,
 ,T45K/springboot-jpa,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,TADSUnivel2015/Jhipsterstore,master,maven,,java8,,,,
@@ -7631,7 +7631,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,TLvanEijk/jhipster_Blog_app,master,maven,,java8,,,,
 ,TMUniversal/RBM,master,,,java8,,,,
 ,TNG/ArchUnit-Examples,main,,,java8,,,,
-,TNG/JGiven,master,,,java8,,,,
+,TNG/JGiven,master,,,java11,,,,
 ,TNG/junit-dataprovider,main,,,java8,,,,
 ,TNG/keycloak-mock,main,,,java8,,,,
 ,TOOP4EU/toop-commons,master,maven,,java8,,,,
@@ -7766,7 +7766,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,TechnionYP5779/team2,master,maven,,java8,,,,
 ,TechnionYP5779/team3,master,maven,,java8,,,,
 ,TechnionYP5779/team4,master,maven,,java8,,,,
-,TechnionYP5779/team5,master,maven,,java8,,,,
+,TechnionYP5779/team5,master,maven,,java11,,,,
 ,TechnionYP5779/team6,master,maven,,java8,,,,
 ,TechnionYearlyProject/DailyPulseMe,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,TedaLIEz/ParsingPlayer,master,,,java8,,,,
@@ -7910,7 +7910,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,TianShengBingFeiNiuRen/SpringBoot_SpringSecurity_JWT,master,maven,,java8,,,,
 ,Tibolte/Android-Anim-Playground,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,Tickaroo/tikxml,master,,,java8,,,,
-,Tillerino/Tillerinobot,master,maven,,java8,,,,
+,Tillerino/Tillerinobot,master,maven,,java11,,,,
 ,Tim-Demo/JVL,master,maven,,java8,,,,
 ,Tim-Demo/Java-Demo,main,maven,,java8,,,,
 ,TimWhiteSource/EasyBuggyPrioritize,main,maven,,java8,,,,
@@ -7923,7 +7923,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Tinkoff/decoro,master,,,java8,,,,
 ,Tinkoff/tinkoff-asdk-android,master,,,java8,,,,
 ,TinuK/jhipsterSampleApplication,master,maven,,java8,,,,
-,TinyZzh/StructUtil,master,,,java8,,,,
+,TinyZzh/StructUtil,master,,,java17,,,,
 ,TipCRM/travel,dev,maven,,java8,,,,
 ,Tirasa/ConnIdADBundle,master,maven,,java8,,,,
 ,Tirasa/ConnIdZimbraBundle,master,maven,,java8,,,,
@@ -8021,7 +8021,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Twebor/trevgerr,master,maven,,java8,,,,
 ,TwiN/spring-security-oauth2-client-example,master,maven,,java8,,,,
 ,TwilioDevEd/sdk-starter-java,master,maven,,java8,,,,
-,Twitter4J/Twitter4J,master,maven,,java8,,,,
+,Twitter4J/Twitter4J,master,maven,,java17,,,,
 ,TwoStone/gradle-eclipse-compiler-plugin,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,TwrpBuilder/twrpbuilder_tree_generator,master,,,java8,,,,
 ,TyCoding/spring-boot,master,maven,,java8,,,,
@@ -8229,7 +8229,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Unidata/ncWMS,main,maven,,java8,,,,
 ,Unidata/netcdf-java,maint-5.x,,,java8,,,,
 ,Unidata/rosetta,main,,,java8,,,,
-,Unidata/threddsIso,main,maven,,java8,,,,
+,Unidata/threddsIso,main,maven,,java11,,,,
 ,Unity-Group/gradle-lazy-credentials,master,,,java8,,,,
 ,Unity-Technologies/unity-ads-android,master,,,java8,,,,
 ,UniversaBlockchain/universa,master,,,java8,,,,
@@ -8255,7 +8255,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,UrielCh/legacy,master,maven,,java8,,,,
 ,UrszulaSlusarz/webapplication,master,maven,,java8,,,,
 ,UseHover/HoverStarter,master,,,java8,,,,
-,User1-NEC/Webgoat1,main,maven,,java8,,,,
+,User1-NEC/Webgoat1,main,maven,,java17,,,,
 ,Ushiosan23/resgen,main,,,java8,,,,
 ,UweTrottmann/tmdb-java,main,maven,,java8,,,,
 ,V-yg/BgMan,master,maven,,java8,,,,
@@ -8282,13 +8282,13 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ValhelsiaTeam/Valhelsia-Structures,1.18,,,java8,,,,
 ,Valkryst/V2DAudio,master,maven,,java8,,,,
 ,Valkryst/V2DSprite,master,maven,,java8,,,,
-,Valkryst/VChat,master,maven,,java8,,,,
+,Valkryst/VChat,master,maven,,java11,,,,
 ,Valkryst/VController,master,maven,,java8,,,,
 ,Valkryst/VDice,master,maven,,java8,,,,
 ,Valkryst/VNameGenerator,master,maven,,java8,,,,
 ,Valkryst/VParser_CFG,master,maven,,java8,,,,
 ,Valkryst/VTemperature,master,maven,,java8,,,,
-,Valkryst/VTerminal,master,maven,,java8,,,,
+,Valkryst/VTerminal,master,maven,,java20,,,,
 ,Valkryst/VUDP,master,maven,,java8,,,,
 ,Valky93/devops,master,maven,,java8,,,,
 ,ValueQuoSPL/Back-Buckswise,master,maven,,java8,,,,
@@ -8332,7 +8332,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Versent/oauthTests,master,maven,,java8,,,,
 ,Vertispan/j2clmavenplugin,main,maven,,java8,,,,
 ,Vhati/OpenUHS,master,,gradle,java8,,,,
-,ViBiOh/spring-web-bp,main,maven,,java8,,,,
+,ViBiOh/spring-web-bp,main,maven,,java17,,,,
 ,ViHtarb/Tooltip,master,,,java8,,,,
 ,ViaVersion/ViaBackwards,master,,,java8,,,,
 ,ViaVersion/ViaRewind,master,maven,,java8,,,,
@@ -8455,10 +8455,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,WangPengGuy/OscilloscopeDemo,master,,,java8,,,,
 ,Wangqge/PowerLog_ae,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,WantedTechnologies/xpresso,master,maven,,java8,,,,
-,Warchant/iroha-pure-java,v1.0.0_rc2,,,java8,,,,
+,Warchant/iroha-pure-java,v1.0.0_rc2,,,java8,,,TRUE,Gradle wrapper 4.8 is not supported
 ,Warchant/testcontainers-iroha,v1.0.0_rc2,,,java8,,,,
 ,Waschndolos/gradle-license-guard,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
-,WaterdogPE/WaterdogPE,master,maven,,java8,,,,
+,WaterdogPE/WaterdogPE,master,maven,,java11,,,,
 ,Watson-ljf/netty-book2-ljf,master,maven,,java8,,,,
 ,WeAreWizards/passopolis-server,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,WeBankBlockchain/Data-Reconcile,master,,,java8,,,,
@@ -8517,8 +8517,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,WesGtoX/combat-atari,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,WestRidgeSystems/jmisb,main,maven,,java8,,,,
 ,WhareHauora/wharehauora-android,master,,,java8,,,,
-,Wheaties247/MtgEmulator,master,,,java8,,,,
-,Whiley/WhileyCompiler,main,maven,,java8,,,,
+,Wheaties247/MtgEmulator,master,,,java8,,,TRUE,Gradle wrapper 4.5.1 is not supported
+,Whiley/WhileyCompiler,main,maven,,java11,,,,
 ,WhiteO/cosmoport,master,maven,,java8,,,,
 ,WhiteO/ftse-original,master,maven,,java8,,,,
 ,WhiteO/rp,master,maven,,java8,,,,
@@ -8574,7 +8574,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Williamhuawei/incubator-dubbo,master,maven,,java8,,,,
 ,Willing-Xyz/RestDoc,master,maven,,java8,,,,
 ,WillyShakes/UdooWtf,master,,,java8,,,,
-,Wilm0r/giggity,master,,,java8,,,,
+,Wilm0r/giggity,master,,,java11,,,,
 ,WilmerQ/Acceso-Universidad-Magdalena,master,maven,,java8,,,,
 ,WilmerQ/Acira-Backend,master,maven,,java8,,,,
 ,WilmerQ/Fundegirc,master,maven,,java8,,,,
@@ -8637,7 +8637,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,XigniteX666/owasp,master,maven,,java8,,,,
 ,Xilinx/RapidWright,master,,,java8,,,,
 ,Xin-Felix/Mango,master,,,java8,,,TRUE,Top-level build tool file is missing
-,XingdongYu/QQNaviView,master,,,java8,,,,
+,XingdongYu/QQNaviView,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,Xitikit/iqserver-gradle,master,,,java8,,,,
 ,XiumingLee/SpringBootVueJWT,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,XorDzik/LabEhcache,master,maven,,java8,,,,
@@ -8716,7 +8716,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,Yin-Hongwei/music-website,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,Yingliang-Du/jee-sample-projects,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,YiuChoi/SportEditor,master,,,java8,,,,
-,Yiuman/citrus,master,maven,,java8,,,,
+,Yiuman/citrus,master,maven,,java11,,,,
 ,Ykuee/eclipse-workSpace,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,Yleisradio/neo4j-rest-api-for-id-generation,master,maven,,java8,,,,
 ,Ylianst/MeshCentralAndroidAgent,main,,,java8,,,,
@@ -8800,7 +8800,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ZenGirl/EmbeddedJettyRepository,master,maven,,java8,,,,
 ,Zenika/zenilan,master,maven,,java8,,,,
 ,ZenjiHK/Tienda-Online,master,maven,,java8,,,,
-,Zephery/newblog,master,maven,,java8,,,,
+,Zephery/newblog,master,maven,,java11,,,,
 ,Zeral-Zhang/manager_system,master,maven,,java8,,,,
 ,Zerekiel/EIP_PROJECT,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,Zerekiel/HealthSafe_mobile,master,,,java8,,,,
@@ -8850,7 +8850,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ZuInnoTe/hadoopoffice,main,,,java8,,,,
 ,ZuYun/Jgraph,master,,gradle,java8,,,,
 ,Zuehlke/SHMACK,master,,,java8,,,TRUE,Build uses Gradle 2.x
-,Zuluft/AutoAdapter,master,,,java8,,,,
+,Zuluft/AutoAdapter,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,Zweihui/RxFingerPrinter,master,,,java8,,,,
 ,Zygnik/BrainSqueeze,master,,,java8,,,,
 ,Zyonic-Software/Maddox-V2,master,,,java8,,,,
@@ -9004,7 +9004,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,aboullaite/Multi-Client-Server-chat-application,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,aboutsip/pkts,master,maven,,java8,,,,
 ,abrenoch/hyperion-android-grabber,master,,,java8,,,,
-,abrensch/brouter,master,,,java8,,,,
+,abrensch/brouter,master,,,java11,,,,
 ,abslanka/nipslanka-bkp,master,maven,,java8,,,,
 ,absolutegalaber/jwt-oauth2-example,master,maven,,java8,,,,
 ,abstractj/kalium,master,maven,,java8,,,,
@@ -9013,7 +9013,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,abvashis/jhipster-storeapp,master,maven,,java8,,,,
 ,abxaz92/WildflyJaasModule,master,maven,,java8,,,,
 ,abxworld/Final,master,maven,,java8,,,,
-,abymsft/azfunc-java,main,maven,,java8,,,,
+,abymsft/azfunc-java,main,maven,,java11,,,,
 ,acai-bjca/Laboratorio7,master,maven,,java8,,,,
 ,acbg19963/MulticServer,master,maven,,java8,,,,
 ,accenture/mercury,master,maven,,java8,,,,
@@ -9045,7 +9045,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,acruise/cassandra-bloom-filter,master,maven,,java8,,,,
 ,act262/GradleTimeTracker,master,,,java8,,,,
 ,act262/PinModePlugin,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
-,act262/gradle-to-bazel,master,,,java8,,,,
+,act262/gradle-to-bazel,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,acterics/apk-dependency-graph-gradle-plugin,master,,,java8,,,,
 ,actframework/actframework,master,maven,,java8,,,,
 ,actions-on-google/smart-home-java,master,,,java8,,,,
@@ -9070,19 +9070,19 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,adaptris-labs/interlok-twilio-sms,develop,,,java8,,,,
 ,adaptris/interlok,develop,,,java11,,,,
 ,adaptris/interlok-activemq,develop,,,java8,,,,
-,adaptris/interlok-amqp,develop,,,java8,,,,
+,adaptris/interlok-amqp,develop,,,java11,,,,
 ,adaptris/interlok-apache-http,develop,,,java8,,,,
 ,adaptris/interlok-api,develop,,,java8,,,,
 ,adaptris/interlok-artemis,develop,,,java8,,,,
 ,adaptris/interlok-artifact-downloader,develop,,,java8,,,,
 ,adaptris/interlok-aws,develop,,,java8,,,,
-,adaptris/interlok-azure,develop,,,java8,,,,
+,adaptris/interlok-azure,develop,,,java11,,,,
 ,adaptris/interlok-cache,develop,,,java8,,,,
 ,adaptris/interlok-cassandra,develop,,,java8,,,,
 ,adaptris/interlok-cluster-manager,develop,,,java8,,,,
 ,adaptris/interlok-config-conditional,develop,,,java8,,,,
 ,adaptris/interlok-container,develop,,,java8,,,,
-,adaptris/interlok-csv,develop,,,java8,,,,
+,adaptris/interlok-csv,develop,,,java11,,,,
 ,adaptris/interlok-csv-json,develop,,,java8,,,,
 ,adaptris/interlok-custom-component-example,gradle,,,java8,,,,
 ,adaptris/interlok-cxf,develop,,,java8,,,,
@@ -9093,12 +9093,12 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,adaptris/interlok-es-rest,develop,,,java8,,,,
 ,adaptris/interlok-es5,develop,,,java8,,,,
 ,adaptris/interlok-excel,develop,,,java8,,,,
-,adaptris/interlok-exec,develop,,,java8,,,,
+,adaptris/interlok-exec,develop,,,java11,,,,
 ,adaptris/interlok-expressions,develop,,,java8,,,,
 ,adaptris/interlok-failover,develop,,,java8,,,,
 ,adaptris/interlok-filesystem,develop,,,java11,,,,
 ,adaptris/interlok-flatfile,develop,,,java8,,,,
-,adaptris/interlok-flyway,develop,,,java8,,,,
+,adaptris/interlok-flyway,develop,,,java11,,,,
 ,adaptris/interlok-gcloud-pubsub,develop,,,java8,,,,
 ,adaptris/interlok-hpcc,develop,,,java11,,,,
 ,adaptris/interlok-installer,develop,,,java8,,,,
@@ -9107,18 +9107,18 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,adaptris/interlok-jolokia,develop,,,java8,,,,
 ,adaptris/interlok-jq,develop,,,java8,,,,
 ,adaptris/interlok-jruby,develop,,,java8,,,,
-,adaptris/interlok-json,develop,,,java8,,,,
+,adaptris/interlok-json,develop,,,java11,,,,
 ,adaptris/interlok-json-streaming,develop,,,java8,,,,
 ,adaptris/interlok-kafka,develop,,,java8,,,,
-,adaptris/interlok-kie,develop,,,java8,,,,
+,adaptris/interlok-kie,develop,,,java11,,,,
 ,adaptris/interlok-kubernetes,develop,,,java8,,,,
 ,adaptris/interlok-legacyhttp,develop,,,java8,,,,
-,adaptris/interlok-mail,develop,,,java8,,,,
+,adaptris/interlok-mail,develop,,,java11,,,,
 ,adaptris/interlok-mongodb,develop,,,java8,,,,
 ,adaptris/interlok-mqtt,develop,,,java8,,,,
 ,adaptris/interlok-nats,develop,,,java8,,,,
 ,adaptris/interlok-oauth,develop,,,java8,,,,
-,adaptris/interlok-okhttp,develop,,,java8,,,,
+,adaptris/interlok-okhttp,develop,,,java11,,,,
 ,adaptris/interlok-pdf,develop,,,java8,,,,
 ,adaptris/interlok-pgp,develop,,,java8,,,,
 ,adaptris/interlok-profiler,develop,,,java8,,,,
@@ -9137,7 +9137,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,adaptris/interlok-vcs-git,develop,,,java11,,,,
 ,adaptris/interlok-verify-report,develop,,,java11,,,,
 ,adaptris/interlok-vertx,develop,,,java8,,,,
-,adaptris/interlok-wmq,develop,,,java8,,,,
+,adaptris/interlok-wmq,develop,,,java11,,,,
 ,adaptris/interlok-work-unit,develop,,,java8,,,,
 ,adaptris/interlok-workflow-rest-services,develop,,,java8,,,,
 ,adaptris/interlok-xinclude,develop,,,java8,,,,
@@ -9263,10 +9263,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,adobe/target-java-sdk-samples,master,,,java8,,,,
 ,adobe/toughday2,master,maven,,java8,,,,
 ,adobe/workflow-variable-externalizer,master,maven,,java8,,,,
-,adobe/xdm-event-model,master,maven,,java8,,,,
+,adobe/xdm-event-model,master,maven,,java11,,,,
 ,adohe-zz/etcd4j,master,maven,,java8,,,,
 ,adolfobrunno/points,master,maven,,java8,,,,
-,adonespitogo/AdoBot,master,,,java8,,,,
+,adonespitogo/AdoBot,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,adorsys/keycloak-config-cli,main,maven,,java11,,,,
 ,adorsys/keycloak-password-encryption,master,maven,,java8,,,,
 ,adorsys/oauth2-pkce,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -9516,7 +9516,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,akaigoro/df4j,API-8,maven,,java8,,,,
 ,akaita/easylauncher-gradle-plugin,master,,,java8,,,,
 ,akaleek/jhi,master,maven,,java8,,,,
-,akardapolov/ASH-Viewer,master,maven,,java8,,,,
+,akardapolov/ASH-Viewer,master,maven,,java11,,,,
 ,akarnokd/RxJavaExtensions,3.x,,,java8,,,,
 ,akarnokd/RxJavaInterop,3.x,,,java8,,,,
 ,akarnokd/ixjava,1.x,,,java8,,,,
@@ -9594,7 +9594,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,albertomolon/vulnerable-app,master,,,java8,,,,
 ,albertonavarro/loggergenerator-gradle-plugin,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,albertopeam/Android-Infrastructure,master,,,java8,,,,
-,albertoruibal/carballo,master,,gradle,java8,,,,
+,albertoruibal/carballo,master,,gradle,java11,,,,
 ,albestia/shaxpsCore,master,maven,,java8,,,,
 ,albfernandez/juniversalchardet,main,maven,,java8,,,,
 ,albinmathew/PhotoCrop,master,,,java8,,,,
@@ -9806,7 +9806,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,alibaba/innodb-java-reader,master,maven,,java8,,,,
 ,alibaba/jarslink,master,maven,,java8,,,,
 ,alibaba/java-dns-cache-manipulator,main,maven,,java8,,,,
-,alibaba/jetcache,master,maven,,java8,,,,
+,alibaba/jetcache,master,maven,,java11,,,,
 ,alibaba/jstorm,master,maven,,java8,,,,
 ,alibaba/jvm-sandbox,master,maven,,java8,,,,
 ,alibaba/jvm-sandbox-repeater,master,maven,,java8,,,,
@@ -9957,13 +9957,13 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,alphagov/locate-api-frontend,master,maven,,java8,,,,
 ,alphagov/notifications-java-client,master,maven,,java8,,,,
 ,alphagov/notifications-java-user-research-app,master,,,java8,,,,
-,alphagov/pay-adminusers,master,maven,,java8,,,,
-,alphagov/pay-connector,master,maven,,java8,,,,
+,alphagov/pay-adminusers,master,maven,,java11,,,,
+,alphagov/pay-connector,master,maven,,java11,,,,
 ,alphagov/pay-direct-debit-connector,master,maven,,java8,,,,
 ,alphagov/pay-java-commons,master,maven,,java8,,,,
 ,alphagov/pay-partner-integrations,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,alphagov/pay-products,master,maven,,java8,,,,
-,alphagov/pay-publicapi,master,maven,,java8,,,,
+,alphagov/pay-publicapi,master,maven,,java11,,,,
 ,alphagov/pay-publicauth,master,maven,,java8,,,,
 ,alphagov/pay-reactive-backend-examples,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,alphagov/prometheus_demo,master,maven,,java8,,,,
@@ -10069,7 +10069,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,americanexpress/SPAN,master,maven,,java8,,,,
 ,americanexpress/bloom,master,maven,,java8,,,,
 ,americanexpress/defaultoffers-client-jvm,master,maven,,java8,,,,
-,americanexpress/dydaq,master,maven,,java8,,,,
+,americanexpress/dydaq,master,maven,,java17,,,,
 ,americanexpress/jakapu,master,maven,,java8,,,,
 ,americanexpress/jakasu,master,maven,,java8,,,,
 ,americanexpress/jexm,master,maven,,java8,,,,
@@ -10121,7 +10121,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,amolggavali4/ticketing,master,maven,,java8,,,,
 ,amontJ/code_spring,master,,,java8,,,,
 ,amourany/seasons-of-serverless,master,,,java8,,,TRUE,Top-level build tool file is missing
-,ampersanda/SMK-Coding,master,,,java8,,,,
+,ampersanda/SMK-Coding,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,ampersanda/dicoding-KADE-FootballMatchSchedule,master,,,java8,,,,
 ,ampersanda/dicoding-KADE-footballclub,master,,,java8,,,,
 ,ampersanda/processing-android-test,master,,,java8,,,,
@@ -10183,7 +10183,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,anassibnouali/jhipsterSampleApplication,master,maven,,java8,,,,
 ,anataliocs/cz,master,maven,,java8,,,,
 ,anatawa12/DecompileCrasher,master,,,java8,,,,
-,anatawa12/auto-tostring,master,,,java8,,,,
+,anatawa12/auto-tostring,master,,,java11,,,,
 ,anatawa12/auto-visitor,master,,,java8,,,,
 ,anatawa12/compile-time-constant,master,,,java8,,,,
 ,anatawa12/jar-in-jar-mod,master,,,java8,,,,
@@ -10229,13 +10229,13 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,andreimenin/listatelefonica,master,maven,,java8,,,,
 ,andremion/Floating-Navigation-View,master,,,java8,,,,
 ,andremion/Louvre,development,,,java8,,,,
-,andremion/Music-Player,master,,,java8,,,,
-,andreoss/etoile,master,maven,,java8,,,,
+,andremion/Music-Player,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
+,andreoss/etoile,master,maven,,java11,,,,
 ,andreschaffer/event-sourcing-cqrs-examples,master,maven,,java8,,,,
 ,andreschaffer/microservices-testing-examples,master,maven,,java8,,,,
 ,andrescv/jupiter,main,,,java8,,,,
 ,andresoviedo/google-drive-ftp-adapter,master,maven,,java8,,,,
-,andresth/Kandroid,master,,,java8,,,,
+,andresth/Kandroid,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,andretadeu/jdeps-gradle-plugin,master,,,java8,,,,
 ,andrethomazini/converters,master,maven,,java8,,,,
 ,andretietz/retroauth,master,,,java8,,,,
@@ -10423,7 +10423,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,anlingyi/xechat,master,maven,,java8,,,,
 ,anlrsejava/od,master,maven,,java8,,,,
 ,anlrsejava/wrkr,master,maven,,java8,,,,
-,annadowling/aws,master,,,java8,,,,
+,annadowling/aws,master,,,java8,,,TRUE,Gradle wrapper 4.8.1 is not supported
 ,annamanakina/TestMP3Player,master,,,java8,,,,
 ,annocence/hipmediadb,master,maven,,java8,,,,
 ,anntru/eservice,master,maven,,java8,,,,
@@ -10456,10 +10456,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,anthonycr/Lightning-Browser,dev,,,java8,,,,
 ,anthonyikeda-cf/greeting-plugin,master,,gradle,java8,,,,
 ,anthonynsimon/java-ds-algorithms,master,,,java8,,,,
-,anthonyraymond/joal,master,maven,,java8,,,,
+,anthonyraymond/joal,master,maven,,java11,,,,
 ,anthonyu/KeptCollections,master,maven,,java8,,,,
 ,antlr/antlr3,master,maven,,java8,,,,
-,antlr/antlr4,master,maven,,java8,,,,
+,antlr/antlr4,master,maven,,java11,,,,
 ,antlr/antlr4-intellij-adaptor,master,,,java8,,,,
 ,antlr/antlrworks,master,maven,,java8,,,,
 ,antlr/codebuff,master,maven,,java8,,,,
@@ -10478,7 +10478,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,anton-liauchuk/java-interview,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,anton217/restapp,master,maven,,java8,,,,
 ,antonKozyriatskyi/CircularProgressIndicator,dev,,,java8,,,,
-,antonakospanos/petstore,develop,maven,,java8,,,,
+,antonakospanos/petstore,develop,maven,,java11,,,,
 ,antonarhipov/jpoint,master,maven,,java8,,,,
 ,antonchar/User-Service,master,maven,,java8,,,,
 ,antoniobattista/jhipster-sample-application1,master,maven,,java8,,,,
@@ -10708,7 +10708,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,apache/directory-kerby,trunk,maven,,java8,,,,
 ,apache/directory-ldap-api,master,maven,,java8,,,,
 ,apache/directory-mavibot,master,maven,,java8,,,,
-,apache/directory-scimple,develop,maven,,java11,,,,
+,apache/directory-scimple,develop,maven,,java17,,,,
 ,apache/directory-server,master,maven,,java8,,,,
 ,apache/directory-studio,master,maven,,java11,,,,
 ,apache/distributedlog,master,maven,,java8,,,,
@@ -10911,7 +10911,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,apache/jackrabbit,trunk,maven,,java8,,,,
 ,apache/jackrabbit-filevault,master,maven,,java11,,,,
 ,apache/jackrabbit-filevault-package-maven-plugin,master,maven,,java11,,,,
-,apache/jackrabbit-oak,trunk,maven,,java8,,,,
+,apache/jackrabbit-oak,trunk,maven,,java11,,,,
 ,apache/jackrabbit-ocm,trunk,maven,,java8,,,,
 ,apache/james-hupa,trunk,maven,,java8,,,,
 ,apache/james-jdkim,master,maven,,java8,,,,
@@ -11118,7 +11118,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,apache/oodt,master,maven,,java8,,,,
 ,apache/oozie,master,maven,,java8,,,,
 ,apache/openjpa,master,maven,,java8,,,,
-,apache/openmeetings,master,maven,,java8,,,,
+,apache/openmeetings,master,maven,,java11,,,,
 ,apache/opennlp,master,maven,,java11,,,,
 ,apache/openwebbeans,master,maven,,java8,,,,
 ,apache/openwebbeans-meecrowave,master,maven,,java8,,,,
@@ -11223,7 +11223,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,apache/shiro,main,maven,,java8,,,,
 ,apache/sirona,trunk,maven,,java8,,,,
 ,apache/sis,master,maven,,java11,,,,
-,apache/skywalking,master,,,java8,,,,
+,apache/skywalking,master,,,java11,,,,
 ,apache/skywalking-agent-test-tool,master,maven,,java8,,,,
 ,apache/skywalking-banyandb-java-client,main,maven,,java8,,,,
 ,apache/skywalking-java,main,maven,,java8,,,,
@@ -11811,7 +11811,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,archi-mbo/EspaceClient,master,maven,,java8,,,,
 ,archi-mbo/jhipsterSampleApplication,master,maven,,java8,,,,
 ,archiecobbs/dellroad-stuff,master,maven,,java8,,,,
-,archiecobbs/hl7lib,master,maven,,java8,,,,
+,archiecobbs/hl7lib,master,maven,,java11,,,,
 ,archimatetool/archi,master,maven,,java11,,,,
 ,archord/gwac_content,master,maven,,java8,,,,
 ,arcnrick/cursomc,master,maven,,java8,,,,
@@ -11842,7 +11842,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,arimus/jmimemagic,master,maven,,java8,,,,
 ,arineng/rdap_bootstrap_server,master,,,java8,,,,
 ,ariscruz/jhipster,master,maven,,java8,,,,
-,aritraroy/KerningViews,master,,,java8,,,,
+,aritraroy/KerningViews,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,aritraroy/PatternLockView,master,,,java8,,,TRUE,Build uses Gradle 3.x
 ,arjan-bal/software-product-sprint,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,arjanfrans/mario-game,master,,,java8,,,,
@@ -11914,7 +11914,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,art-community/application-gradle-plugin,main,,,java8,,,,
 ,art-community/art-java,main,,,java8,,,,
 ,arteam/unitils,master,maven,,java8,,,,
-,artem-smotrakov/tlsbunny,master,maven,,java8,,,,
+,artem-smotrakov/tlsbunny,master,maven,,java11,,,,
 ,artem-zinnatullin/AssertParcelable,master,,,java8,,,,
 ,artem-zinnatullin/AutoJackson,master,,,java8,,,,
 ,artem-zinnatullin/RxUi,master,,,java8,,,,
@@ -11948,7 +11948,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,arunas-stonis/jhipster2-with-jwt2,master,maven,,java8,,,,
 ,arunkumar9t2/scabbard,main,,,java8,,,,
 ,arunkumarmn9/JWT-Authentication,master,maven,,java8,,,,
-,arvindhiman/productapi,main,maven,,java8,,,,
+,arvindhiman/productapi,main,maven,,java11,,,,
 ,arvinljw/ThumbUpSample,master,,,java8,,,,
 ,arvist/Prototype1,master,maven,,java8,,,,
 ,arx-deidentifier/arx,master,maven,,java8,,,,
@@ -11957,7 +11957,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,as0ler/Android-Tools,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,as81397333/dubbo-spring-boot-project,master,maven,,java8,,,,
 ,asLody/SandHook,master,,,java8,,,,
-,asad/ReactionDecoder,master,maven,,java8,,,,
+,asad/ReactionDecoder,master,maven,,java11,,,,
 ,asakusafw/asakusafw,master,maven,,java8,,,,
 ,asakusafw/asakusafw-mapreduce,master,maven,,java8,,,,
 ,asana/java-asana,master,maven,,java8,,,,
@@ -11967,7 +11967,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,asc-lab/dotnetcore-microservices-poc,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,ascemama/JWT4B_Fork,master,maven,,java8,,,,
 ,ascendtech/gwt-gradle,master,,,java8,,,,
-,asciidocfx/AsciidocFX,master,maven,,java8,,,,
+,asciidocfx/AsciidocFX,master,maven,,java20,,,,
 ,asciidoctor/asciidoclet,master,maven,,java8,,,,
 ,asciidoctor/asciidoctor-gradle-examples,master,,,java8,,,,
 ,asciidoctor/asciidoctor-gradle-plugin,master,,,java8,,,,
@@ -11976,7 +11976,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ascopes/jct,main,maven,,java8,,,,
 ,asdaqul/asdaqul_qoilin_17.12.0244,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,asdf2014/ThirdPartPay,master,maven,,java8,,,,
-,asdf2014/yuzhouwan,master,maven,,java8,,,,
+,asdf2014/yuzhouwan,master,maven,,java11,,,,
 ,asdfjkl/jerry,master,maven,,java8,,,,
 ,asdhammu/Library,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,aseduma/SpringBasic,master,maven,,java8,,,,
@@ -12032,7 +12032,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,aspose-pdf-cloud/aspose-pdf-cloud-java,master,,,java8,,,TRUE,Build uses Gradle 3.x
 ,aspose-pdf/Aspose.PDF-for-Java,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,assecoTomas/hibernate-orm-3.6,master,,,java8,,,TRUE,Build uses Gradle 2.x
-,assertj/assertj,main,maven,,java8,,,,
+,assertj/assertj,main,maven,,java11,,,,
 ,assertj/assertj-core,main,maven,,java8,,,,
 ,assertj/assertj-db,main,maven,,java8,,,,
 ,assertj/assertj-generator-gradle-plugin,main,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
@@ -12050,11 +12050,11 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,astuetz/PagerSlidingTabStrip,master,,,java8,,,,
 ,asual/lesscss-engine,master,maven,,java8,,,,
 ,aswathamkumari/ESRSApplication,master,maven,,java8,,,,
-,asyard/asocialoud,master,maven,,java8,,,,
+,asyard/asocialoud,master,maven,,java11,,,,
 ,asyard/jhipstertest-2,master,maven,,java8,,,,
 ,asyncapi/jasyncapi,master,maven,,java8,,,,
 ,ata-mokim/alienmw,main,maven,,java8,,,,
-,ata4/bspsrc,master,maven,,java8,,,,
+,ata4/bspsrc,master,maven,,java11,,,,
 ,ata4/disunity,master,maven,,java8,,,,
 ,atanasovskib/DAG_Task_Scheduler,main,,,java8,,,,
 ,atanughosh1981/bank,master,maven,,java8,,,,
@@ -12491,7 +12491,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,banica-org/dojo,master,maven,,java8,,,,
 ,banmajio/RTSPtoHTTP-FLV,master,maven,,java8,,,,
 ,banshita209/Euphoria-Health-Care,master,maven,,java8,,,,
-,baobaovt/CodeReviewLab,master,maven,,java8,,,,
+,baobaovt/CodeReviewLab,master,maven,,java17,,,,
 ,baobeta/ToiecOnline,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,baomidou/MybatisX,dev,,,java8,,,,
 ,baomidou/dynamic-datasource-spring-boot-starter,master,maven,,java8,,,,
@@ -12742,7 +12742,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,bhawanihmh/npvrdemospringboot,master,maven,,java8,,,,
 ,bherbst/FragmentTransitionSample,master,,,java8,,,,
 ,bherbst/QuickReturnFooterSample,master,,,java8,,,,
-,bhlangonijr/chesslib,master,maven,,java8,,,,
+,bhlangonijr/chesslib,master,maven,,java11,,,,
 ,bhoflack/spring-security-test,master,maven,,java8,,,,
 ,bhs-sawsen/FirstJhipsterApp,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,bhuemer/gbt,main,,,java8,,,,
@@ -12893,7 +12893,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,bitleak/java-lmstfy-client,master,maven,,java8,,,,
 ,bitletorg/bitlet,master,maven,,java8,,,,
 ,bitletorg/weupnp,master,maven,,java8,,,,
-,bitquest/bitquest,master,maven,,java8,,,,
+,bitquest/bitquest,master,maven,,java11,,,,
 ,bitrise-io/android-sdk22-code-sign,master,,,java8,,,,
 ,bitrise-io/sample-apps-android-sdk22,master,,,java8,,,,
 ,bitronix/btm,master,maven,,java8,,,,
@@ -12990,7 +12990,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,bloomreach/xm-s3-manager,master,maven,,java8,,,,
 ,bloomreach/zk-replicator,master,maven,,java8,,,,
 ,blouke/IRProjectEval,master,maven,,java8,,,,
-,blox/blox,dev,,,java8,,,,
+,blox/blox,dev,,,java8,,,TRUE,Gradle wrapper 4.3 is not supported
 ,blueSky1125/jhipster-sample-application,main,maven,,java8,,,,
 ,blueapron/marinator,master,,,java8,,,,
 ,bluecitymoon/hello,master,maven,,java8,,,,
@@ -13001,7 +13001,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,bluecrystalsign/signer-source,master,maven,,java8,,,,
 ,bluejoe2008/openwebflow,master,maven,,java8,,,,
 ,bluelamar/WsRuler,master,maven,,java8,,,,
-,bluelinelabs/Conductor,develop,,,java8,,,,
+,bluelinelabs/Conductor,develop,,,java11,,,,
 ,bluelinelabs/LoganSquare,development,,,java8,,,TRUE,Build uses Gradle 2.x
 ,bluemapleman/NewsRecommendSystem,master,maven,,java8,,,,
 ,bluepapa32/gradle-watch-plugin,master,,,java8,,,,
@@ -13202,7 +13202,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,bozaro/git-lfs-migrate,master,,,java8,,,,
 ,bparlette/moviedb,master,maven,,java8,,,,
 ,bparmentier/OpenBikeSharing,master,,,java8,,,,
-,bparmentier/WiFiKeyShare,master,,,java8,,,,
+,bparmentier/WiFiKeyShare,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,bpear/ARChon-Packager,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,bpellin/keepassdroid,master,,,java8,,,,
 ,bpetrovpaysafe/jhipster-sample-project,master,maven,,java8,,,,
@@ -13287,7 +13287,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,brianway/algorithms-learning,master,maven,,java8,,,,
 ,brianway/spring-learning,master,maven,,java8,,,,
 ,brianway/webporter,master,maven,,java8,,,,
-,brianwernick/ExoMedia,master,,,java8,,,,
+,brianwernick/ExoMedia,master,,,java11,,,,
 ,brianwhu/xillium,master,maven,,java8,,,,
 ,brice-dymas/ambassade,master,maven,,java8,,,,
 ,brice-dymas/epressing,master,maven,,java8,,,,
@@ -13345,7 +13345,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,brucetoo/PickView,master,,,java8,,,,
 ,brucetoo/PinterestView,master,,,java8,,,,
 ,brucetoo/VideoControllerView,master,,,java8,,,,
-,brunoborges/webfx,master,maven,,java8,,,,
+,brunoborges/webfx,master,maven,,java11,,,,
 ,brunocleite/spring-boot-exception-handling,master,maven,,java8,,,,
 ,brunofarache/liferay-sdk-builder,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,brunoguerra/craftMagic,master,,gradle,java8,,,,
@@ -13383,7 +13383,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,bubalehich/Authentication,master,maven,,java8,,,,
 ,bucchi/OAuth2.0ProviderForJava,master,maven,,java8,,,,
 ,bucharest-jug/dropwizard-todo,master,maven,,java8,,,,
-,bucket4j/bucket4j,master,maven,,java8,,,,
+,bucket4j/bucket4j,master,maven,,java11,,,,
 ,buckyroberts/Videos-Android-App,master,,,java8,,,,
 ,buddy-works/simple-java-project,master,maven,,java8,,,,
 ,buddycloud/buddycloud-server-java,master,maven,,java8,,,,
@@ -13394,10 +13394,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,bugix/jsch,master,maven,,java8,,,,
 ,bugsnag/bugsnag-android,next,,,java8,,,,
 ,bugsnag/bugsnag-android-gradle-plugin,next,,,java8,,,,
-,bugsnag/bugsnag-java,master,,,java8,,,,
+,bugsnag/bugsnag-java,master,,,java8,,,TRUE,Gradle wrapper 4.4.1 is not supported
 ,buildcontainers/buildcontainers-gradle-plugin,master,,,java8,,,,
 ,buildheroes/buildheroes-plugin,master,maven,,java8,,,,
-,bujiio/buji-pac4j,master,maven,,java8,,,,
+,bujiio/buji-pac4j,master,maven,,java11,,,,
 ,bukodi/p04,master,maven,,java8,,,,
 ,bulivlad/vertx-codegen-plugin,master,,,java8,,,,
 ,bulldog2011/bigqueue,master,maven,,java8,,,,
@@ -13429,7 +13429,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,buskowsky/RestApp,master,maven,,java8,,,,
 ,buster-wang/jhipster-sample-application,master,maven,,java8,,,,
 ,busyluo/skdjproj,master,maven,,java8,,,,
-,buttasam/cms-boot,master,,,java8,,,,
+,buttasam/cms-boot,master,,,java8,,,TRUE,Gradle wrapper 4.8 is not supported
 ,bvijaycom/jhipster-sample-application,master,maven,,java8,,,,
 ,bvsbrk/BinPacking,master,,,java8,,,,
 ,bwajtr/java-persistence-frameworks-comparison,master,,gradle,java8,,,,
@@ -13457,7 +13457,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,bytehala/android-mqtt-quickstart,master,,,java8,,,,
 ,bytehala/gradle-svnbuildversion,master,,,java8,,,TRUE,Error: Could not find or load main class org.gradle.wrapper.GradleWrapperMain (gradlew present but wrapper jar missing)
 ,bytekast/local-apigateway-gradle-plugin,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
-,bytemanproject/byteman,main,maven,,java8,,,,
+,bytemanproject/byteman,main,maven,,java11,,,,
 ,byzer-org/byzer-cdc,master,maven,,java8,,,,
 ,byzer-org/byzer-datalake,master,maven,,java8,,,,
 ,byzer-org/byzer-lang,master,maven,,java8,,,,
@@ -13627,7 +13627,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,casbin/jcasbin,master,maven,,java8,,,,
 ,casey-erdmann/baseline-sast-testing,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,cashapp/InflationInject,trunk,,,java8,,,,
-,cashapp/misk,master,,,java8,,,,
+,cashapp/misk,master,,,java11,,,,
 ,cashapp/sqldelight,master,,,java8,,,,
 ,cashfree/cashfree-android-sdk-v0,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,casidiablo/android-facebook,master,maven,,java8,,,,
@@ -13725,7 +13725,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,celsott/Courses_Alpha_QS,master,maven,,java8,,,,
 ,cemoral/todo-list-backend,master,maven,,java8,,,,
 ,census-instrumentation/opencensus-java,master,,,java8,,,,
-,centic9/jgit-cookbook,master,,,java8,,,,
+,centic9/jgit-cookbook,master,,,java11,,,,
 ,cenxi/utils,main,maven,,java8,,,,
 ,ceragon/GradleGeneratorPlugin,master,,,java8,,,,
 ,cerberustesting/cerberus-source,master,maven,,java8,,,,
@@ -13785,7 +13785,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,chaingrok/libra4j,master,maven,,java8,,,,
 ,chaingrok/travis-ci-test,master,maven,,java8,,,,
 ,chaitou/spring-framework-master,master,,,java8,,,,
-,chaitu236/TakServer,master,maven,,java8,,,,
+,chaitu236/TakServer,master,maven,,java11,,,,
 ,chakibc18/WORLD,master,maven,,java8,,,,
 ,chakibc18/WORLDWIDE,master,maven,,java8,,,,
 ,chakibc18/myApp,master,maven,,java8,,,,
@@ -13846,7 +13846,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,che-samples/console-java-simple,master,,gradle,java8,,,,
 ,che-samples/java-guestbook,master,maven,,java8,,,,
 ,checkmarx-ltd/cx-flow,develop,,,java8,,,,
-,checkstyle/checkstyle,master,maven,,java8,,,,
+,checkstyle/checkstyle,master,maven,,java11,,,,
 ,checkstyle/sonar-checkstyle,master,maven,,java8,,,,
 ,checomperez31/jhipsterSampleApplication,master,maven,,java8,,,,
 ,cheepinator/SESE_GRP_3_Translator,master,maven,,java8,,,,
@@ -13967,7 +13967,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,chocoteam/choco-report,master,maven,,java8,,,,
 ,chocoteam/choco-sat,master,maven,,java8,,,,
 ,chocoteam/choco-solver,master,maven,,java11,,,,
-,chocoteam/cutoffseq,master,maven,,java8,,,,
+,chocoteam/cutoffseq,master,maven,,java11,,,,
 ,chocoteam/pf4cs,master,maven,,java8,,,,
 ,chomatdam/upday-services,master,maven,,java8,,,,
 ,chomman/cpr,master,maven,,java8,,,,
@@ -14035,7 +14035,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,christophesmet/colorpicker,master,,,java8,,,,
 ,christophetd/log4shell-vulnerable-app,main,,,java8,,,,
 ,christophstrobl/spring-data-solr-showcase,master,maven,,java8,,,,
-,chrisvest/stormpot,3.2,maven,,java8,,,,
+,chrisvest/stormpot,3.2,maven,,java11,,,,
 ,chrpnv/jsp,master,maven,,java8,,,,
 ,chrsan/css-selectors,master,maven,,java8,,,,
 ,chsmy/CitySelector,master,,,java8,,,,
@@ -14048,7 +14048,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,chudsaviet/gradle-avrohugger-plugin,master,,,java8,,,,
 ,chung10/spring-boot-filemanager,master,maven,,java8,,,,
 ,chungkwong/MathOCR,master,maven,,java8,,,,
-,chunky-dev/chunky,master,,,java8,,,,
+,chunky-dev/chunky,master,,,java11,,,,
 ,chunquedong/axbasePlugin,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,chunxinhou/elastic-job,master,maven,,java8,,,,
 ,chuongbui/jhipsterSample1,master,maven,,java8,,,,
@@ -14072,12 +14072,12 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,cinchapi/jarsh,master,,,java8,,,,
 ,cincheo/jsweet,develop,,,java8,,,TRUE,Top-level build tool file is missing
 ,cindyklr/jhipsterSampleApplication,master,maven,,java8,,,,
-,cindywushu/11,master,,,java8,,,,
+,cindywushu/11,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,cinnober/semver-git,master,,,java8,,,,
 ,cinyee1214/CourseSelectionSystem_React,master,maven,,java8,,,,
 ,ciprianparaschivescu91/betcip,master,maven,,java8,,,,
 ,circonus-labs/fq,master,,,java8,,,TRUE,Top-level build tool file is missing
-,circumgraph/circumgraph,main,maven,,java8,,,,
+,circumgraph/circumgraph,main,maven,,java11,,,,
 ,ciriti/CDelivery,develop,,,java8,,,,
 ,cisagov/log4j-scanner,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,cisco/jfnr,master,maven,,java8,,,,
@@ -14105,7 +14105,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,cjdev/interview-preparation,master,maven,,java8,,,,
 ,cjiahuan/TrimmerVideoView,master,,,java8,,,,
 ,cjqian/codeu_project,master,,,java8,,,TRUE,Top-level build tool file is missing
-,cjudd/wordyninjablog,main,,,java8,,,,
+,cjudd/wordyninjablog,main,,,java11,,,,
 ,cjwizard/cjwizard,master,maven,,java8,,,,
 ,ck-wizard/BigFileUpload,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,ckabates/az-java-func,main,maven,,java8,,,,
@@ -14358,7 +14358,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,coi-gov-pl/spring-clean-architecture,develop,maven,,java8,,,,
 ,coinbase/coinbase-android-sdk,master,maven,,java8,,,,
 ,coinbase/coinbase-android-sdk-example,master,,,java8,,,,
-,cojen/Tupl,master,maven,,java8,,,,
+,cojen/Tupl,master,maven,,java17,,,,
 ,cokia/dustlst,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,coldbrewtea/pdf_converter,master,maven,,java8,,,,
 ,coldvmoon/hispterstore,master,maven,,java8,,,,
@@ -14377,7 +14377,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,cometchat-pro/android-java-chat-app,master,,,java8,,,,
 ,cometd/cometd,5.0.x,maven,,java8,,,,
 ,cometkim/jdbc-jett-renderer,master,,,java8,,,,
-,comixed/comixed,master,maven,,java8,,,,
+,comixed/comixed,master,maven,,java11,,,,
 ,commercetools/commercetools-jvm-sdk,master,maven,,java8,,,,
 ,commercetools/commercetools-sync-java,master,,,java8,,,,
 ,commercetools/rmf-codegen,main,,,java8,,,,
@@ -14462,7 +14462,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,coobird/thumbnailator,master,maven,,java8,,,,
 ,cookpad/LicenseToolsPlugin,master,,,java8,,,,
 ,cookpad/android-code-style,master,,,java8,,,,
-,cookpad/puree-android,master,,,java8,,,,
+,cookpad/puree-android,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,cool-squad/cool,master,maven,,java8,,,,
 ,cooldryx/Nichijou,master,maven,,java8,,,,
 ,coolerfall/Android-AppDaemon,master,,,java8,,,,
@@ -14494,7 +14494,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,cortinico/kotlin-gradle-plugin-template,master,,,java8,,,,
 ,cortinico/ktfmt-gradle,main,,,java8,,,,
 ,cortinico/slidetoact,main,,,java8,,,,
-,corunet/kloadgen,master,maven,,java8,,,,
+,corunet/kloadgen,master,maven,,java11,,,,
 ,corydissinger/raw4j,master,maven,,java8,,,,
 ,coryleeio/Mapgen,master,maven,,java8,,,,
 ,corymsmith/react-native-fabric,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -14564,7 +14564,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,crate/crate,master,,,java8,,,,
 ,crate/crate-commoncrawl,master,,,java8,,,,
 ,crate/crate-example-plugin,master,,,java8,,,,
-,crate/crate-java-testing,master,,,java8,,,,
+,crate/crate-java-testing,master,,,java11,,,,
 ,crate/crate-jdbc,master,,,java8,,,,
 ,crate/crate-mesos-framework,master,,,java8,,,,
 ,crate/crate-sample-apps,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -14572,7 +14572,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,crate/elasticsearch-timefacets-plugin,master,maven,,java8,,,,
 ,crate/jmx_exporter,master,,,java8,,,,
 ,crawler-commons/crawler-commons,master,maven,,java8,,,,
-,crawljax/crawljax,master,maven,,java8,,,,
+,crawljax/crawljax,master,maven,,java11,,,,
 ,craypellaUAH/School_Projects,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,crazyandcoder/citypicker,master,,,java8,,,,
 ,crazycodeboy/TakePhoto,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
@@ -14595,7 +14595,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,criccomini/ezdb,master,maven,,java8,,,,
 ,cricketbackground/excel-parser,master,,,java8,,,,
 ,cricketsamya/gradle-plugin-sysnode,master,,,java8,,,,
-,criemen/ql-data-flow,master,,,java8,,,,
+,criemen/ql-data-flow,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,criemen/ql-data-flow-examples,master,,,java8,,,,
 ,crippled-ankle/Comminimizer-BackEnd,master,maven,,java8,,,,
 ,cris001/MyRepo,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -14627,7 +14627,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,crotwell/gradle-macappbundle,master,,gradle,java8,,,,
 ,crotwell/version-class,master,,,java8,,,,
 ,crowlas/jhipster-sample-application,master,maven,,java8,,,,
-,croz-ltd/klokwrk-project,master,,,java8,,,,
+,croz-ltd/klokwrk-project,master,,,java17,,,,
 ,cruzer45/HashCalculator,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,cruzrazeto/project-jsf,master,maven,,java8,,,,
 ,crykn/libgdx-screenmanager,master,,,java8,,,,
@@ -14835,8 +14835,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,d4rken-org/reddit-android-appstore,dev,,,java8,,,,
 ,d4rth-v4d3r/presto,master,maven,,java8,,,,
 ,d761472032/MyDemo,master,maven,,java8,,,,
-,dCache/dcache,master,maven,,java8,,,,
-,dCache/nfs4j,master,maven,,java8,,,,
+,dCache/dcache,master,maven,,java11,,,,
+,dCache/nfs4j,master,maven,,java11,,,,
 ,dCache/oncrpc4j,master,maven,,java8,,,,
 ,dCentralizedSystems/core,master,maven,,java8,,,,
 ,daaao/app,master,maven,,java8,,,,
@@ -14983,7 +14983,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,dankurka/mgwt,master,maven,,java8,,,,
 ,danmigwi74/SmartKart_App,master,,,java8,,,,
 ,danmoop/GitPals,master,maven,,java8,,,,
-,dannil/scb-java-client,dev,maven,,java8,,,,
+,dannil/scb-java-client,dev,maven,,java11,,,,
 ,danoz73/RecyclerViewFastScroller,master,,,java8,,,,
 ,danshannon/javastravav3api,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,danskespil/gradle-plugin-release,master,,,java8,,,TRUE,Build uses Gradle 3.x
@@ -15024,7 +15024,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,darklam/SQLite-Database-Test-Android,master,,,java8,,,,
 ,darklam/StockMarketSim-Android,master,,,java8,,,,
 ,darkmatter18/Digi-Sence,master,,,java8,,,,
-,darkmatter18/HelpME,master,,,java8,,,,
+,darkmatter18/HelpME,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,darknessNight/AutoUpdateLauncher,master,maven,,java8,,,,
 ,darko1002001/android-rest-client,master,,,java8,,,,
 ,darkone2k4/jhipsterSampleApplication,master,maven,,java8,,,,
@@ -15191,7 +15191,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ddcoding/webDealer,master,maven,,java8,,,,
 ,ddd-by-examples/all-things-cqrs,master,maven,,java8,,,,
 ,ddd-by-examples/event-source-cqrs-sample,master,,,java8,,,,
-,ddd-by-examples/factory,master,,,java8,,,,
+,ddd-by-examples/factory,master,,,java8,,,TRUE,Gradle wrapper 4.8 is not supported
 ,dddddddsqdfqs/devops,master,maven,,java8,,,,
 ,ddddog/springBootMultiDataSource,master,maven,,java8,,,,
 ,dddjava/jig,main,,,java11,,,,
@@ -15363,7 +15363,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,developerdave/BugTrackerJHipster,master,maven,,java8,,,,
 ,developersdo/Leer-JSON-desde-API-en-Java,master,maven,,java8,,,,
 ,developersdo/dev-dom-skills-ws,master,maven,,java8,,,,
-,developersu/ns-usbloader,master,maven,,java8,,,,
+,developersu/ns-usbloader,master,maven,,java11,,,,
 ,developersu/ns-usbloader-mobile,master,,,java8,,,,
 ,develophil/jhipster-sample-pack,master,maven,,java8,,,,
 ,devender-yadav/GitUserDetailsFinder,master,maven,,java8,,,,
@@ -15518,7 +15518,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,diffblue/ecommerce-demo,master,maven,,java8,,,,
 ,diffblue/java-demo,master,maven,,java8,,,,
 ,diffblue/java-models-library,master,maven,,java8,,,,
-,diffplug/atplug,main,,,java8,,,,
+,diffplug/atplug,main,,,java11,,,,
 ,diffplug/blowdryer,main,,,java8,,,,
 ,diffplug/cache-horizon,master,,,java8,,,,
 ,diffplug/durian,master,,,java8,,,,
@@ -15618,7 +15618,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,disparter/msstudygateway,master,maven,,java8,,,,
 ,disqus/graphite-reporter-agent,master,maven,,java8,,,,
 ,dita-ot/dita-ot,develop,,,java8,,,,
-,ditclear/TimeLine,master,,,java8,,,,
+,ditclear/TimeLine,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,dittos/animeta,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,diva-e/talk-javassist,master,maven,,java8,,,,
 ,divinespear/jpa-schema-maven-plugin,master,maven,,java8,,,,
@@ -15630,7 +15630,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,dj3500/hightail,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,djag-qld/documentproduction,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,django205/QRcodegenerator,master,,,java8,,,,
-,djangofan/chord-bars,master,maven,,java8,,,,
+,djangofan/chord-bars,master,maven,,java11,,,,
 ,djcass44/gradle-util-plugin,master,,,java8,,,,
 ,djeneboumadi/ProjetProMaster2,Main,maven,,java8,,,,
 ,djfearon/COSC591_ConnectX,master,maven,,java8,,,,
@@ -15724,7 +15724,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,dmfs/express,master,,,java8,,,,
 ,dmfs/gitversion,main,,,java11,,,,
 ,dmfs/http-client-essentials-suite,master,,,java8,,,,
-,dmfs/instantpicker,master,,,java8,,,,
+,dmfs/instantpicker,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,dmfs/iterators,master,,,java8,,,,
 ,dmfs/jems,master,,,java8,,,,
 ,dmfs/lib-recur,master,,,java8,,,,
@@ -15733,7 +15733,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,dmfs/optional,master,,,java8,,,,
 ,dmfs/retention-magic,master,,,java8,,,,
 ,dmfs/rfc5545-datetime,master,,,java8,,,,
-,dmfs/semver,main,,,java8,,,,
+,dmfs/semver,main,,,java11,,,,
 ,dmfs/senoritas,main,,,java8,,,,
 ,dmfs/srcless,main,,,java8,,,,
 ,dmfs/uri-toolkit,master,,,java8,,,,
@@ -15783,7 +15783,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,dockerunit/dockerunit-consul,master,maven,,java8,,,,
 ,dockerunit/dockerunit-junit4,master,maven,,java8,,,,
 ,dockerunit/dockerunit-junit5,master,maven,,java8,,,,
-,dockstore/cwlavro,main,maven,,java8,,,,
+,dockstore/cwlavro,main,maven,,java11,,,,
 ,dockstore/dockstore,develop,maven,,java11,,,,
 ,dockstore/dockstore-cli,develop,maven,,java8,,,,
 ,docopt/docopt.java,master,maven,,java8,,,,
@@ -15907,7 +15907,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,dqvn/MSGateway,master,maven,,java8,,,,
 ,draco1023/panda,master,maven,,java8,,,,
 ,draeger-lab/insilico,master,maven,,java8,,,,
-,draftcode/ijaas,master,,,java8,,,,
+,draftcode/ijaas,master,,,java11,,,,
 ,dragangabriel/PoliWebsite,master,maven,,java8,,,,
 ,draganvelkovski/jhipsterBaseApplication,master,maven,,java8,,,,
 ,dragao1995/licitacaoweb,master,maven,,java8,,,,
@@ -15921,7 +15921,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,drakeet/retrofit-agera-call-adapter,master,,,java8,,,,
 ,drallieiv/KinanCity,develop,maven,,java8,,,,
 ,drambol/workspace,master,,,java8,,,TRUE,Top-level build tool file is missing
-,dramollei/atomgame,main,maven,,java8,,,,
+,dramollei/atomgame,main,maven,,java17,,,,
 ,drasyl-overlay/drasyl,master,maven,,java11,,,,
 ,drazisil/Mailit,master,,,java8,,,,
 ,drazisil/_archives,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -15978,7 +15978,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,dronavallisaikrishna/jhipster-coding,master,maven,,java8,,,,
 ,dronekit/dronekit-android,develop,,,java8,,,,
 ,dronky/user-catalog,master,maven,,java8,,,,
-,droolsjbpm/drools,main,maven,,java8,,,,
+,droolsjbpm/drools,main,maven,,java11,,,,
 ,dropbox/dropbox-sdk-java,master,,,java8,,,,
 ,dropbox/mypy-PyCharm-plugin,master,,,java8,,,,
 ,dropwizard-bundles/dropwizard-configurable-assets-bundle,master,maven,,java8,,,,
@@ -16012,7 +16012,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,dsachdev-faststart2018/bookingservice,master,maven,,java8,,,,
 ,dscabral/Codes,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,dscalzi/ZipExtractor,master,,,java8,,,,
-,dschadow/CloudSecurity,main,maven,,java8,,,,
+,dschadow/CloudSecurity,main,maven,,java17,,,,
 ,dschadow/Java-EE-Security,main,maven,,java8,,,,
 ,dschadow/Java-Web-Security,main,maven,,java8,,,,
 ,dschadow/JavaSecurity,main,maven,,java8,,,,
@@ -16051,7 +16051,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,dtrujillog-umg/calculadora_Derivadas,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,dtrung98/MusicPlayer,master,,,java8,,,,
 ,dtx12/AndroidAnimationsActions,master,,,java8,,,,
-,duanhong169/ColorPicker,master,,,java8,,,,
+,duanhong169/ColorPicker,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,duanhong169/PickerView,master,,,java8,,,,
 ,duannhqb/knlmbe,master,maven,,java8,,,,
 ,duanxingchen/nifi,master,maven,,java8,,,,
@@ -16091,7 +16091,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,duosecurity/duo_oam_plugin,master,maven,,java8,,,,
 ,dupengtao/BubbleTextView,master,,,java8,,,,
 ,duracell71/jhipsterSampleApplication,master,maven,,java8,,,,
-,dushixiang/kafka-map,master,maven,,java8,,,,
+,dushixiang/kafka-map,master,maven,,java17,,,,
 ,dustedrob/JStrava,master,,,java8,,,,
 ,dustin/java-memcached-client,master,maven,,java8,,,,
 ,dustinkredmond/FXTrayIcon,main,maven,,java8,,,,
@@ -16271,7 +16271,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,eclipse-ee4j/eclipselink-workbench,master,maven,,java8,,,,
 ,eclipse-ee4j/enterprise-deployment,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,eclipse-ee4j/exousia,1,maven,,java8,,,,
-,eclipse-ee4j/expressly,master,maven,,java8,,,,
+,eclipse-ee4j/expressly,master,maven,,java11,,,,
 ,eclipse-ee4j/glassfish,master,maven,,java8,,,,
 ,eclipse-ee4j/glassfish-build-maven-plugin,master,maven,,java8,,,,
 ,eclipse-ee4j/glassfish-cdi-porting-tck,master,maven,,java8,,,,
@@ -16306,7 +16306,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,eclipse-ee4j/jpa-api,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,eclipse-ee4j/jsonp,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,eclipse-ee4j/jstl-api,master,maven,,java8,,,,
-,eclipse-ee4j/krazo,master,maven,,java8,,,,
+,eclipse-ee4j/krazo,master,maven,,java11,,,,
 ,eclipse-ee4j/mail,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,eclipse-ee4j/management-api,master,maven,,java8,,,,
 ,eclipse-ee4j/metro-mimepull,master,maven,,java8,,,,
@@ -16321,9 +16321,9 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,eclipse-ee4j/orb-gmbal-pfl,master,maven,,java8,,,,
 ,eclipse-ee4j/parsson,master,maven,,java8,,,,
 ,eclipse-ee4j/soteria,master,maven,,java8,,,,
-,eclipse-ee4j/starter,master,maven,,java8,,,,
+,eclipse-ee4j/starter,master,maven,,java11,,,,
 ,eclipse-ee4j/tyrus,master,maven,,java8,,,,
-,eclipse-ee4j/wasp,master,maven,,java8,,,,
+,eclipse-ee4j/wasp,master,maven,,java11,,,,
 ,eclipse-embed-cdt/eclipse-plugins,master,maven,,java8,,,,
 ,eclipse-iofog/Agent,develop,,,java8,,,,
 ,eclipse-passage/passage-spring,master,,,java8,,,,
@@ -16332,7 +16332,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,eclipse-vertx/vertx-sql-client,master,maven,,java8,,,,
 ,eclipse/ConfigJSR,master,maven,,java8,,,,
 ,eclipse/Xpect,master,maven,,java8,,,,
-,eclipse/aCute,master,maven,,java8,,,,
+,eclipse/aCute,master,maven,,java17,,,,
 ,eclipse/ajdt,master,maven,,java11,,,,
 ,eclipse/aspectj.eclipse.jdt.core,main,maven,,java8,,,,
 ,eclipse/birt,master,maven,,java11,,,,
@@ -16357,7 +16357,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,eclipse/cft,master,maven,,java8,,,,
 ,eclipse/che-che4z-lsp-for-cobol,development,,,java8,,,TRUE,Top-level build tool file is missing
 ,eclipse/concierge,master,,,java8,,,,
-,eclipse/corrosion,master,maven,,java11,,,,
+,eclipse/corrosion,master,maven,,java17,,,,
 ,eclipse/dartboard,master,maven,,java8,,,,
 ,eclipse/dash-licenses,master,maven,,java11,,,,
 ,eclipse/dawnsci,master,maven,,java8,,,,
@@ -16392,7 +16392,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,eclipse/january-forms,master,maven,,java8,,,,
 ,eclipse/jetty.alpn.api,master,maven,,java8,,,,
 ,eclipse/jetty.project,jetty-10.0.x,maven,,java11,,,,
-,eclipse/jetty.toolchain,master,maven,,java8,,,,
+,eclipse/jetty.toolchain,master,maven,,java11,,,,
 ,eclipse/jkube,master,maven,,java8,,,,
 ,eclipse/jnosql,master,maven,,java11,,,,
 ,eclipse/jnosql-communication-driver,master,maven,,java11,,,,
@@ -16420,9 +16420,9 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,eclipse/lemminx,main,maven,,java8,,,,
 ,eclipse/lemminx-maven,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,eclipse/leshan,master,maven,,java8,,,,
-,eclipse/lsp4e,master,maven,,java11,,,,
+,eclipse/lsp4e,master,maven,,java17,,,,
 ,eclipse/lsp4j,main,,,java8,,,,
-,eclipse/lyo,master,maven,,java8,,,,
+,eclipse/lyo,master,maven,,java11,,,,
 ,eclipse/lyo.designer,master,maven,,java11,,,,
 ,eclipse/microprofile,master,maven,,java8,,,,
 ,eclipse/microprofile-conference,master,maven,,java8,,,,
@@ -16460,9 +16460,9 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,eclipse/paho.mqtt-spy,master,maven,,java8,,,,
 ,eclipse/paho.mqtt.android,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,eclipse/paho.mqtt.java,master,maven,,java8,,,,
-,eclipse/pdt,master,maven,,java11,,,,
+,eclipse/pdt,master,maven,,java17,,,,
 ,eclipse/poosl,main,maven,,java11,,,,
-,eclipse/rdf4j,main,maven,,java8,,,,
+,eclipse/rdf4j,main,maven,,java11,,,,
 ,eclipse/rdf4j-storage,master,maven,,java8,,,,
 ,eclipse/rdf4j-testsuite,master,maven,,java8,,,,
 ,eclipse/rdf4j-tools,master,maven,,java8,,,,
@@ -16470,12 +16470,12 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,eclipse/repairnator,master,maven,,java8,,,,
 ,eclipse/richbeans,master,maven,,java8,,,,
 ,eclipse/scanning,master,maven,,java8,,,,
-,eclipse/shellwax,master,maven,,java11,,,,
+,eclipse/shellwax,master,maven,,java17,,,,
 ,eclipse/sisu.inject,master,maven,,java11,,,,
-,eclipse/sisu.mojos,master,maven,,java8,,,,
+,eclipse/sisu.mojos,master,maven,,java11,,,,
 ,eclipse/sisu.plexus,master,maven,,java11,,,,
 ,eclipse/smarthome,master,maven,,java8,,,,
-,eclipse/smartmdsd,master,maven,,java8,,,,
+,eclipse/smartmdsd,master,maven,,java11,,,,
 ,eclipse/steady,master,maven,,java8,,,,
 ,eclipse/sw360,master,maven,,java8,,,,
 ,eclipse/tahu,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -16483,15 +16483,15 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,eclipse/thym,master,maven,,java8,,,,
 ,eclipse/tm4e,master,maven,,java11,,,,
 ,eclipse/transformer,main,maven,,java8,,,,
-,eclipse/tycho,master,maven,,java11,,,,
+,eclipse/tycho,master,maven,,java17,,,,
 ,eclipse/unide.java,master,maven,,java8,,,,
 ,eclipse/vert.x,master,maven,,java8,,,,
 ,eclipse/vorto,development,maven,,java8,,,,
-,eclipse/wildwebdeveloper,master,maven,,java11,,,,
+,eclipse/wildwebdeveloper,master,maven,,java17,,,,
 ,eclipse/windowbuilder,master,maven,,java11,,,,
 ,eclipse/winery,main,maven,,java8,,,,
-,eclipse/xtext-core,master,,,java8,,,,
-,eclipse/xtext-eclipse,master,maven,,java8,,,,
+,eclipse/xtext-core,master,,,java11,,,,
+,eclipse/xtext-eclipse,master,maven,,java11,,,,
 ,eclipse/xtext-extras,master,,,java8,,,,
 ,eclipse/xtext-lib,master,,,java8,,,,
 ,eclipse/xtext-web,master,,,java8,,,,
@@ -16510,7 +16510,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,edgexfoundry/export-distro,master,maven,,java8,,,,
 ,editorconfig-checker/editorconfig-checker.java,master,,,java8,,,,
 ,edlovesjava/blog-tut,master,maven,,java8,,,,
-,edmcouncil/rdf-toolkit,master,maven,,java8,,,,
+,edmcouncil/rdf-toolkit,master,maven,,java11,,,,
 ,edmodo/cropper,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,edmund-wagner/junrar,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,edodemuru/GymMobile,master,,,java8,,,,
@@ -16631,7 +16631,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,elastic/apm-agent-java-plugin-example,main,maven,,java11,,,,
 ,elastic/attached-artifact-enforcer,master,maven,,java8,,,,
 ,elastic/die-with-dignity-plugin,master,maven,,java8,,,,
-,elastic/ecs-logging-java,main,maven,,java8,,,,
+,elastic/ecs-logging-java,main,maven,,java11,,,,
 ,elastic/elasticsearch,master,,,java17,,,,
 ,elastic/elasticsearch-hadoop,main,,,java8,,,,
 ,elastic/elasticsearch-hdfs,master,maven,,java8,,,,
@@ -16653,7 +16653,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,elastic/jrmonitor,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,elastic/jvm-languages-sniffer,master,,,java8,,,,
 ,elastic/leakchecker,master,maven,,java8,,,,
-,elastic/logstash,main,,,java8,,,,
+,elastic/logstash,main,,,java11,,,,
 ,elastic/mocksocket,master,maven,,java8,,,,
 ,elastic/newspotter,main,maven,,java8,,,,
 ,elastic/opbeans-java,main,,,java8,,,TRUE,Top-level build tool file is missing
@@ -16699,7 +16699,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,eleventy7/eider,master,,,java8,,,,
 ,elexis/elexis-3-core,master,maven,,java11,,,,
 ,elgamala/ontology,master,,,java8,,,TRUE,Top-level build tool file is missing
-,elgamala/rest-service,master,,,java8,,,,
+,elgamala/rest-service,master,,,java8,,,TRUE,Gradle wrapper 4.5.1 is not supported
 ,elgris/microservice-app-example,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,eliagh/my-staff,master,maven,,java8,,,,
 ,eliagh/test-1,master,maven,,java8,,,,
@@ -16747,14 +16747,14 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,embulk/embulk-input-jdbc,master,,,java8,,,,
 ,embulk/embulk-output-jdbc,master,,,java8,,,,
 ,embulk/gradle-embulk-plugins,master,,,java8,,,,
-,emdete/tabulae,master,,,java8,,,,
+,emdete/tabulae,master,,,java8,,,TRUE,Gradle wrapper 4.5.1 is not supported
 ,emerie-1/pharm,master,,,java8,,,,
 ,emersinlioglu/jhipster,master,maven,,java8,,,,
 ,emersoncantalice/juris-facile-server,master,maven,,java8,,,,
 ,emetriq/gradle-changelog-plugin,master,,,java8,,,,
 ,emfjson/emfjson-jackson,master,maven,,java8,,,,
 ,emicastellanos/eternity_solver,master,,gradle,java8,,,,
-,emichael/dslabs,master,,,java8,,,,
+,emichael/dslabs,master,,,java17,,,,
 ,emiissa/continental,master,maven,,java8,,,,
 ,emikra/vertx-json-http-request,master,maven,,java8,,,,
 ,emilio89/pruebaBack,master,maven,,java8,,,,
@@ -16798,7 +16798,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,enghwa/springboot-fargate-cdk,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,enginebai/SwagPoints,master,,,java8,,,,
 ,engineerafo/newfunction,main,maven,,java8,,,,
-,englishand/springboot,master,maven,,java8,,,,
+,englishand/springboot,master,maven,,java11,,,,
 ,engravor/sumed,master,maven,,java8,,,,
 ,engsrbg/gateway_microserviceuploader_V1.03,master,maven,,java8,,,,
 ,enigma-beep/BobbleAssessment,master,,,java8,,,,
@@ -16837,7 +16837,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,epam/cloud-pipeline,develop,,,java8,,,,
 ,epam/eco-commons,master,maven,,java8,,,,
 ,epam/eco-commons-avro,master,maven,,java8,,,,
-,epam/eco-commons-kafka,master,maven,,java8,,,,
+,epam/eco-commons-kafka,master,maven,,java11,,,,
 ,epam/eco-kafka-manager,master,maven,,java8,,,,
 ,epam/eco-schema-catalog,master,maven,,java8,,,,
 ,epam/fonda,develop,,,java8,,,,
@@ -16849,7 +16849,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ephemeral-laboratories/whitesource-gradle-plugin,main,,,java8,,,,
 ,epickrram/grav,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,epickrram/perf-workshop,master,,,java8,,,TRUE,Build uses Gradle 2.x
-,epickrram/proxygen,master,,,java8,,,,
+,epickrram/proxygen,master,,,java8,,,TRUE,Gradle wrapper 4.2.1 is not supported
 ,epickrram/transport,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,epics-base/epicsCoreJava,master,maven,,java8,,,,
 ,epitschke/gradle-file-versioning,main,,,java8,,,,
@@ -16996,7 +16996,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,etiennestuder/java-ordered-properties,main,,,java8,,,,
 ,etiennestuder/teamcity-build-scan-plugin,main,,,java8,,,,
 ,etraveli/bom-verifier,master,,,java8,,,TRUE,Build uses Gradle 3.x
-,etri/DFaaSCloud,master,maven,,java8,,,,
+,etri/DFaaSCloud,master,maven,,java11,,,,
 ,etsy/AndroidStaggeredGrid,master,,,java8,,,TRUE,Build uses Gradle 1.x
 ,etsy/PushBot,master,maven,,java8,,,,
 ,etsy/arbiter,master,maven,,java8,,,,
@@ -17117,7 +17117,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,eyedeekay/Simplest-Possible-I2P-for-Andoid-Embedding-Example,main,,,java8,,,,
 ,eyedeekay/So-You-Want-To-Write-A-SAM-Library,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,eyedeekay/brb,main,,,java8,,,TRUE,Top-level build tool file is missing
-,eyedeekay/jeepget,master,,,java8,,,,
+,eyedeekay/jeepget,master,,,java8,,,TRUE,Gradle wrapper 4.4.1 is not supported
 ,eyeem/decorator,master,,,java8,,,,
 ,eyeem/router,master,,,java8,,,,
 ,eyskim/Pack_Frenzy,dev,,,java8,,,,
@@ -17145,7 +17145,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,fa1c0n1/ondev_v6.2.1,main,maven,,java8,,,,
 ,fabasoad/commons-lang,master,maven,,java8,,,,
 ,fabasoad/computer-science-java,master,maven,,java8,,,,
-,fabasoad/sma-site,main,maven,,java8,,,,
+,fabasoad/sma-site,main,maven,,java11,,,,
 ,fabg21/my-sport-gateway,master,maven,,java8,,,,
 ,fabianishere/kotlin-plugin-generated,master,,,java8,,,,
 ,fabiano1749/cepalab,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -17263,7 +17263,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,fangx/HaoRefresh,master,,,java8,,,,
 ,fangx/ZhiHuMVP,master,,,java8,,,,
 ,fangyidong/json-simple,master,maven,,java8,,,,
-,fanhonest/XUI,master,,,java8,,,,
+,fanhonest/XUI,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,fanhua1994/DzFilter,master,maven,,java8,,,,
 ,fanhua1994/XBaseAndroid,master,,,java8,,,,
 ,fanhualei/wukong-framework,master,maven,,java8,,,,
@@ -17279,7 +17279,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,farhan889/jhipsterSampleApplication,master,maven,,java8,,,,
 ,farhantandia/Wearable-Sensor-Data-Collector,master,,,java8,,,,
 ,faridfaridfarid/coinbot,master,maven,,java8,,,,
-,farin/JCloisterZone,master,maven,,java8,,,,
+,farin/JCloisterZone,master,maven,,java11,,,,
 ,farukcuha/GazeteYazarlari,master,,,java8,,,,
 ,farzad-sedaghatbin/bebarbiarCore,master,maven,,java8,,,,
 ,farzad-sedaghatbin/dagalaServer,master,maven,,java8,,,,
@@ -17300,7 +17300,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,fatihsrepo/Projeler,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,faucamp/SimpleRtmp,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,fazdevils/workout-tracker,develop,maven,,java8,,,,
-,fazhongxu/LBannerView,master,,,java8,,,,
+,fazhongxu/LBannerView,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,fbab/filrouge0,master,maven,,java8,,,,
 ,fbacchella/LogHub,master,maven,,java8,,,,
 ,fbarthelery/gradle-avdl,master,,,java8,,,,
@@ -17312,7 +17312,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,fbwotjq/byteCodeInstrumentationExample,master,maven,,java8,,,,
 ,fcamblor/springbvjquery,master,maven,,java8,,,,
 ,fcannizzaro/jsoup-annotations,master,,,java8,,,,
-,fccaikai/AppUpdate,master,,,java8,,,,
+,fccaikai/AppUpdate,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,fchenxi/easykafka,master,maven,,java8,,,,
 ,fchwallet/freedriveJ,master,maven,,java8,,,,
 ,fcrepo/fcrepo,main,maven,,java8,,,,
@@ -17353,7 +17353,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,feifa168/mytomcat,master,maven,,java8,,,,
 ,feifanSimple/gmall-parent,master,maven,,java8,,,,
 ,feijifeijivx/jhipsterSampleApplication,master,maven,,java8,,,,
-,feix760/WebViewDebugHook,master,,,java8,,,,
+,feix760/WebViewDebugHook,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,feixiao/DesignPattern,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,feiyanggit/jhipster,master,maven,,java8,,,,
 ,fekracomputers/QuranAndroid,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -17364,7 +17364,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,felipecarvalho-dev/cursomc,master,maven,,java8,,,,
 ,felipecsl/AbsListViewHelper,master,,,java8,,,,
 ,felipecsl/AsymmetricGridView,master,,,java8,,,,
-,felipecsl/GifImageView,master,,,java8,,,,
+,felipecsl/GifImageView,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,felipecsl/QuickReturn,master,,,java8,,,,
 ,felipefzdz/gradle-heroku-plugin,master,,,java8,,,,
 ,felipefzdz/gradle-platform-test-plugin,main,,,java8,,,TRUE,Top-level build tool file is missing
@@ -17409,7 +17409,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,fenjuly/SpinnerLoader,master,,,java8,,,,
 ,fenjuly/ToggleExpandLayout,master,,,java8,,,,
 ,fennifith/Alarmio,main,,,java8,,,,
-,fennifith/TimeDatePicker,master,,,java8,,,,
+,fennifith/TimeDatePicker,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,fenrisf/jhipsterSampleApplication,master,maven,,java8,,,,
 ,fentontaylor/benchmark_compare,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,feritrevor/cookbook_android_task,main,,,java8,,,,
@@ -17429,12 +17429,12 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,feuyeux/jax-rs2-guide-II,master,maven,,java8,,,,
 ,fev/cudu,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,fewlaps/flone-android,master,,,java8,,,,
-,fewlaps/quitnow-cache,master,,,java8,,,,
+,fewlaps/quitnow-cache,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,fex-team/fis-velocity-tools,master,maven,,java8,,,,
 ,ff4j/ff4j,master,maven,,java8,,,,
 ,ffaoudi/jhipsterSampleApplication,master,maven,,java8,,,,
 ,ffay/lanproxy,master,maven,,java8,,,,
-,ffffffff0x/BerylEnigma,master,maven,,java8,,,,
+,ffffffff0x/BerylEnigma,master,maven,,java17,,,,
 ,ffffffff0x/CryptionTool,master,maven,,java8,,,,
 ,ffflorian59/jhipster-sample-application,master,maven,,java8,,,,
 ,ffgiraldez/reactive-mvvm-android,main,,,java8,,,,
@@ -17447,7 +17447,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,fhermansson/assertj-generator-gradle-plugin,master,,,java8,,,,
 ,fhoeben/hsac-fitnesse-fixtures,master,maven,,java8,,,,
 ,fhopf/akka-crawler-example,master,,gradle,java8,,,,
-,fhsiao/jerseysocket,master,,,java8,,,,
+,fhsiao/jerseysocket,master,,,java8,,,TRUE,Gradle wrapper 4.8 is not supported
 ,fhsiao/tomcat-vault,master,,,java8,,,,
 ,fhussonnois/kafkastreams-cep,master,maven,,java8,,,,
 ,ficap/NDCBackuper,master,maven,,java8,,,,
@@ -17560,16 +17560,16 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,fiji/weave_jy2java,master,maven,,java8,,,,
 ,fikrihkll/QuranApp,master,,,java8,,,,
 ,filestack/filestack-android,master,,,java8,,,,
-,filip26/eiger,main,maven,,java8,,,,
+,filip26/eiger,main,maven,,java11,,,,
 ,filip26/hydrogen-yaml,main,maven,,java8,,,,
 ,filip26/id32,main,maven,,java8,,,,
-,filip26/json-ld-cli,main,maven,,java8,,,,
+,filip26/json-ld-cli,main,maven,,java17,,,,
 ,filip26/object-projection,main,maven,,java8,,,,
-,filip26/titanium-json-ld,main,maven,,java8,,,,
+,filip26/titanium-json-ld,main,maven,,java11,,,,
 ,filipebastos/taskmanager,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,filipehcds/BugTrackerJHipster,master,maven,,java8,,,,
 ,filippo-tenaglia/jhipster-universita,master,maven,,java8,,,,
-,filippor/p2Gradle,master,,,java8,,,,
+,filippor/p2Gradle,master,,,java11,,,,
 ,filol/material-preference-library,master,,,java8,,,,
 ,filosganga/gwt-spring-security-sessionless-sample,master,maven,,java8,,,,
 ,find-sec-bugs/find-sec-bugs,master,maven,,java8,,,,
@@ -17606,7 +17606,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,fischermatte/geolud,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,fish-black/microSuite,master,maven,,java8,,,,
 ,fisher-hub/hzz,master,maven,,java8,,,,
-,fishercoder1534/Leetcode,master,,,java8,,,,
+,fishercoder1534/Leetcode,master,,,java8,,,TRUE,Gradle wrapper 4.8.1 is not supported
 ,fishwjy/VideoCompressor,master,,,java8,,,,
 ,fitability/fitability-api,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,fivesmallq/web-data-extractor,master,maven,,java8,,,,
@@ -17683,14 +17683,14 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,florent37/Depth,master,,,java8,,,,
 ,florent37/DiagonalLayout,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,florent37/ExpansionPanel,master,,,java8,,,,
-,florent37/ExpectAnim,master,,,java8,,,,
+,florent37/ExpectAnim,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,florent37/Freezer,master,,,java8,,,,
 ,florent37/GlidePalette,master,,,java8,,,,
 ,florent37/InlineActivityResult,master,,,java8,,,,
 ,florent37/LongShadow,master,,,java8,,,,
 ,florent37/MaterialImageLoading,master,,,java8,,,,
 ,florent37/MaterialViewPager,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
-,florent37/MyLittleCanvas,master,,,java8,,,,
+,florent37/MyLittleCanvas,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,florent37/NewAndroidArchitecture-Component-Github,master,,,java8,,,,
 ,florent37/PicassoPalette,master,,,java8,,,,
 ,florent37/RuntimePermission,master,,,java8,,,,
@@ -17749,7 +17749,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,fmorais95/landlord-application,master,maven,,java8,,,,
 ,fmorbini/scxmlgui,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,fmtlib/fmt,master,,,java8,,,TRUE,Top-level build tool file is missing
-,fmtn/a,master,maven,,java8,,,,
+,fmtn/a,master,maven,,java11,,,,
 ,fmunozse/remotnitoring,master,maven,,java8,,,,
 ,fmunozse/smurf-house,master,maven,,java8,,,,
 ,fneves-datalex/job-node-stalker,master,maven,,java8,,,,
@@ -17768,7 +17768,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,folio-org/mod-permissions,master,maven,,java8,,,,
 ,folio-org/mod-source-record-storage,master,maven,,java8,,,,
 ,folio-org/mod-users,master,maven,,java8,,,,
-,folio-org/okapi,master,maven,,java8,,,,
+,folio-org/okapi,master,maven,,java11,,,,
 ,folkol/jersey-response-tracker,master,maven,,java8,,,,
 ,fomin-zhu/websocket,master,,,java8,,,,
 ,fomin/oas-gen,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -17885,7 +17885,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,freenet-mobile/app,master,,,java8,,,,
 ,freenet/fred,next,,,java8,,,,
 ,freeotp/freeotp-android,master,,,java8,,,,
-,freerouting/freerouting,master,,,java8,,,,
+,freerouting/freerouting,master,,,java11,,,,
 ,freesiads/testProject,master,,,java8,,,,
 ,freestylewill/mybatis-plus-generator,main,maven,,java8,,,,
 ,freew01f/securing-spring-boot-with-jwts,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -17928,7 +17928,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,frost373/w2j-cli,master,maven,,java8,,,,
 ,frostwire/frostwire-jlibtorrent,master,,,java8,,,,
 ,frsab/financial-market,master,maven,,java8,,,,
-,fschopp/issue-tracking,master,maven,,java8,,,,
+,fschopp/issue-tracking,master,maven,,java11,,,,
 ,fschopp/java-futures,master,maven,,java8,,,,
 ,fschopp/java-types,master,maven,,java8,,,,
 ,fschopp/mina-sshd,master,maven,,java8,,,,
@@ -17943,7 +17943,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,fuhong-thoughtworks/testing-demo,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,fuhoujun/e,master,,,java8,,,,
 ,fujaba/fulibGradle,master,,,java8,,,,
-,fujianlian/KLineChart,master,,,java8,,,,
+,fujianlian/KLineChart,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,fujieid/jap,master,maven,,java8,,,,
 ,fulkesko/Prueba_2,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,fullsync/fullsync,master,,,java8,,,,
@@ -17972,7 +17972,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,fusion44/SpotifyStreamer,master,,gradle,java8,,,,
 ,futuredapp/arkitekt,5.x,,,java11,,,,
 ,futuresimple/android-floating-action-button,master,,,java8,,,TRUE,Build uses Gradle 2.x
-,futurewei-cloud/alcor,master,maven,,java8,,,,
+,futurewei-cloud/alcor,master,maven,,java11,,,,
 ,futurewei-cloud/alcor-control-agent,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,futurice/meeting-room-tablet,master,,,java8,,,,
 ,futurice/rx-android-exercise,master,,,java8,,,,
@@ -18042,7 +18042,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,gameontext/gameon-player,main,,,java8,,,,
 ,games647/ChangeSkin,main,maven,,java8,,,,
 ,games647/ColorConsole,main,maven,,java8,,,,
-,games647/FastLogin,main,maven,,java8,,,,
+,games647/FastLogin,main,maven,,java11,,,,
 ,games647/FlexibleLogin,main,maven,,java8,,,,
 ,games647/LagMonitor,main,maven,,java8,,,,
 ,gamesbyangelina/spritely,master,maven,,java8,,,,
@@ -18209,7 +18209,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,geovafc/acaipdejhipster,master,maven,,java8,,,,
 ,geowarin/boot-react,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,geowyck/exemple,master,maven,,java8,,,,
-,gephi/gephi,master,maven,,java8,,,,
+,gephi/gephi,master,maven,,java11,,,,
 ,geraertsf/kbldemo,master,maven,,java8,,,,
 ,gerardsec/pruebaSpringFx,master,maven,,java8,,,,
 ,gered/Llanfair,master,,gradle,java8,,,,
@@ -18251,7 +18251,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ghaseminya/first_jhipster,master,maven,,java8,,,,
 ,ghassen2105/Jhipster-SampleApp,master,maven,,java8,,,,
 ,ghassen2105/JhipsterAngular4,master,maven,,java8,,,,
-,ghatdev/ResturantDemo,master,,,java8,,,,
+,ghatdev/ResturantDemo,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,ghazikr/SpyAppClient,master,,,java8,,,,
 ,ghdefe/miaosha-by-jhipster,main,maven,,java8,,,,
 ,ghdudwkd4/herb,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -18297,7 +18297,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,gismat/spring-firebase-authentication,master,maven,,java8,,,,
 ,git-commit-id/git-commit-id-maven-plugin,master,maven,,java8,,,,
 ,git-sky/threads,master,maven,,java8,,,,
-,git-xuhao/AndroidBaseMvp,master,,,java8,,,,
+,git-xuhao/AndroidBaseMvp,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,gitHub-good/xll-upms,master,maven,,java8,,,,
 ,gitbic/gradle_download_template_plugin,main,,gradle,java8,,,,
 ,gitblit/gitblit,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -18414,7 +18414,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,gmrs/JogoForcaEngSw2,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,gmruiz/jhipster-sample-application,master,maven,,java8,,,,
 ,gmu-swe/phosphor,master,maven,,java8,,,,
-,gnd3bro/cloudev,main,maven,,java8,,,,
+,gnd3bro/cloudev,main,maven,,java11,,,,
 ,gngrOrg/gngr,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,gnigni/jhipdash,master,maven,,java8,,,,
 ,gnigni/jhipster-elasticsearch,master,maven,,java8,,,,
@@ -18481,7 +18481,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,google/android-studio-check,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,google/app-resource-bundle,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,google/archive-patcher,master,,,java8,,,TRUE,Build uses Gradle 2.x
-,google/bamboo-soy,master,,,java8,,,,
+,google/bamboo-soy,master,,,java11,,,,
 ,google/binnavi,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,google/blockly-android,develop,,,java8,,,,
 ,google/bluesky-watchface,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -18610,7 +18610,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,google/step49-2020,master,maven,,java8,,,,
 ,google/supl-client,master,maven,,java8,,,,
 ,google/talkback,master,,gradle,java8,,,,
-,google/tinkCryptoHelper,master,maven,,java8,,,,
+,google/tinkCryptoHelper,master,maven,,java11,,,,
 ,google/translation-cards,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,google/truth,master,maven,,java8,,,,
 ,google/tsunami-security-scanner,master,,,java11,,,,
@@ -18815,7 +18815,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,googlezhang/zhl-jhipster-application,master,maven,,java8,,,,
 ,googolmo/OkVolley,master,,,java8,,,,
 ,gookarthik/SecondAuto,master,maven,,java8,,,,
-,gooroom/gooroom-admin,master,maven,,java8,,,,
+,gooroom/gooroom-admin,master,maven,,java11,,,,
 ,gooroom/gooroom-login-management,master,maven,,java8,,,,
 ,gooroom/gooroom-remote-management,master,maven,,java8,,,,
 ,gopalbala/algoproblems,master,,,java8,,,,
@@ -19047,7 +19047,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,gregorydgraham/DBvolution7,master,maven,,java8,,,,
 ,gregorydgraham/KitombaRoversApp,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,gregorydgraham/PowerRiddle,master,maven,,java8,,,,
-,gregorydgraham/Regexi,main,maven,,java8,,,,
+,gregorydgraham/Regexi,main,maven,,java11,,,,
 ,gregorydgraham/SeparatedString,main,maven,,java8,,,,
 ,gregorydgraham/WetaProcessMemoryJava,master,maven,,java8,,,,
 ,gregwhitaker/gradle-flatbuffers-plugin,master,,,java8,,,,
@@ -19083,17 +19083,17 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,groupon/Message-Bus,master,maven,,java8,,,,
 ,groupon/Novie,master,maven,,java8,,,,
 ,groupon/dependency-injection-checks,master,,,java8,,,,
-,groupon/grox,master,,,java8,,,,
+,groupon/grox,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,groupon/json-schema-validator,master,maven,,java8,,,,
 ,groupon/jtier-ctx,master,maven,,java8,,,,
 ,groupon/locality-uuid.java,master,maven,,java8,,,,
 ,groupon/nakala,master,maven,,java8,,,,
 ,groupon/odo,master,,,java8,,,,
-,groupon/promise,master,maven,,java8,,,,
+,groupon/promise,master,maven,,java11,,,,
 ,groupon/retromock,master,maven,,java8,,,,
 ,groupon/two-to-three,master,maven,,java8,,,,
 ,groupon/vertx-memcache,master,maven,,java8,,,,
-,groupon/vertx-utils,master,maven,,java8,,,,
+,groupon/vertx-utils,master,maven,,java11,,,,
 ,groupsky/android-hamcrest-matchers,master,maven,,java8,,,,
 ,groupsky/nexus4-call-fixer,master,,,java8,,,,
 ,groupsky/roboguice-events,master,maven,,java8,,,,
@@ -19116,7 +19116,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,gsantner/markor,master,,,java8,,,,
 ,gsantner/memetastic,master,,,java8,,,,
 ,gsarradin/geekmaster,master,maven,,java8,,,,
-,gscsocial/gsc-core,master,,,java8,,,,
+,gscsocial/gsc-core,master,,,java8,,,TRUE,Gradle wrapper 4.3 is not supported
 ,gsh199449/spider,master,maven,,java8,,,,
 ,gshipley/openshift3mlbparks,master,maven,,java8,,,,
 ,gsi-upm/Wool,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -19252,8 +19252,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,gwallet/keycloak-sms-authenticator,master,maven,,java8,,,,
 ,gwenshap/kafka-streams-stockstats,master,maven,,java8,,,,
 ,gwhalin/Memcached-Java-Client,master,,,java8,,,TRUE,Top-level build tool file is missing
-,gwizard/gwizard,master,maven,,java8,,,,
-,gwola/gwola-boot,master,,,java8,,,,
+,gwizard/gwizard,master,maven,,java11,,,,
+,gwola/gwola-boot,master,,,java8,,,TRUE,Gradle wrapper 4.8 is not supported
 ,gwqbonc/jhipsterSampleApplication,master,maven,,java8,,,,
 ,gwt-maven-plugin/gwt-maven-plugin,master,maven,,java8,,,,
 ,gwt-plugins/gwt-eclipse-plugin,master,maven,,java8,,,,
@@ -19291,7 +19291,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,h6ah4i/android-materialshadowninepatch,master,,,java8,,,,
 ,h6ah4i/android-tablayouthelper,master,,,java8,,,,
 ,h6ah4i/android-verticalseekbar,master,,,java8,,,,
-,h8/gradle-jooq-example,master,,,java8,,,,
+,h8/gradle-jooq-example,master,,,java8,,,TRUE,Gradle wrapper 4.2.1 is not supported
 ,hImAnShUdHaWaN/mfu,master,maven,,java8,,,,
 ,hWorblehat/gradlecumber,master,,,java8,,,,
 ,hWorblehat/grmarkdown,master,,,java8,,,TRUE,Build uses Gradle 2.x
@@ -19359,7 +19359,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,hamcrest/hamcrest-junit,master,,,java8,,,,
 ,hamedfarahi1/helpTeam,master,maven,,java8,,,,
 ,hamedhsm73/jhipsterSampleApplication,master,maven,,java8,,,,
-,hamidness/restring,master,,,java8,,,,
+,hamidness/restring,master,,,java8,,,TRUE,Gradle wrapper 4.5 is not supported
 ,hamnis/json-collection,master,maven,,java8,,,,
 ,hamzahqureshi/sportial,master,maven,,java8,,,,
 ,hamzapoly/jhipsterSampleApplication,master,maven,,java8,,,,
@@ -19378,7 +19378,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,hanjingyao/app3,master,maven,,java8,,,,
 ,hanjingyao/jhipsterSampleApplication,master,maven,,java8,,,,
 ,hank-cp/spring-static-ctx,master,,,java8,,,,
-,hank-whu/turbo-rpc,master,maven,,java8,,,,
+,hank-whu/turbo-rpc,master,maven,,java11,,,,
 ,hank/litecoinj,master,maven,,java8,,,,
 ,hank927/TracePlugin,master,,,java8,,,,
 ,hank9999/BotConnector,main,maven,,java8,,,,
@@ -19540,7 +19540,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,hazelcast/hazelcast-kubernetes,master,maven,,java8,,,,
 ,hazelcast/hazelcast-simulator,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,hazemkhemiri/jhipsterProth,master,maven,,java8,,,,
-,hazems/mvvm-sample-app,master,,,java8,,,,
+,hazems/mvvm-sample-app,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,hazhang24/jCAT,master,maven,,java8,,,,
 ,hb0730/admin-upms,main,maven,,java8,,,,
 ,hb0730/dbvc,master,maven,,java8,,,,
@@ -19561,7 +19561,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,hbrahi1/calypso_yo,master,maven,,java8,,,,
 ,hbsinosoft/hbinsZuulServer,master,maven,,java8,,,,
 ,hbuck95/DevOpsGroupProject,master,,,java8,,,TRUE,Top-level build tool file is missing
-,hcbarros/test-jsf,main,maven,,java8,,,,
+,hcbarros/test-jsf,main,maven,,java11,,,,
 ,hcgrady2/KotlinJetpackDemo,master,,gradle,java8,,,,
 ,hchaouche/jhipster-sample-application,master,maven,,java8,,,,
 ,hcj11/others,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -19588,7 +19588,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,hdurix/myCellar,develop,maven,,java8,,,,
 ,hdurix/swimming-challenge,develop,maven,,java8,,,,
 ,he2121/MyRPCFromZero,master,maven,,java8,,,,
-,headius/invokebinder,master,maven,,java8,,,,
+,headius/invokebinder,master,maven,,java11,,,,
 ,headius/jo,master,maven,,java8,,,,
 ,headius/options,master,maven,,java8,,,,
 ,healthonnet/hon-lucene-synonyms,master,maven,,java8,,,,
@@ -19729,7 +19729,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,heroku/javasample-redis,master,maven,,java8,,,,
 ,heroku/template-java-embedded-jetty,master,maven,,java8,,,,
 ,heroku/template-java-spring-hibernate,master,maven,,java8,,,,
-,heroku/webapp-runner,main,maven,,java8,,,,
+,heroku/webapp-runner,main,maven,,java11,,,,
 ,herrGrey/JHipsterTest,master,maven,,java8,,,,
 ,hertzsprung/hamcrest-json,master,maven,,java8,,,,
 ,heruoxin/Clip-Stack,master,,,java8,,,,
@@ -19750,7 +19750,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,hewendi/hewendi,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,hex007/freej2me,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,hexdecimal16/Walls,master,,,java8,,,,
-,hexene/LocalVPN,master,,,java8,,,,
+,hexene/LocalVPN,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,hexiangtao/wechat4j,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,hexiaoyanh/hynuxykbackstage,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,hey-dongdong/hey-dongdong,develop,,,java8,,,TRUE,Top-level build tool file is missing
@@ -19822,7 +19822,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,hirakida/gradle-hello-plugin,master,,,java8,,,,
 ,hirdeshtomar/jhipster-sample-application,master,maven,,java8,,,,
 ,hisatti77/scripted-cloud-plugin,master,maven,,java8,,,,
-,hit-mc/BungeeCross,master,maven,,java8,,,,
+,hit-mc/BungeeCross,master,maven,,java17,,,,
 ,hiteshjoshi1/microservice-docker-cart-example,master,maven,,java8,,,,
 ,hitherejoe/Android-Boilerplate,master,,,java8,,,,
 ,hitherejoe/AndroidTvBoilerplate,master,,,java8,,,,
@@ -19856,7 +19856,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,hmakroum/QuestionApp,master,maven,,java8,,,,
 ,hmcts/ccd-api-gateway,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,hmcts/ccd-config-generator,master,,,java8,,,,
-,hmcts/ccd-data-store-api,master,,,java8,,,,
+,hmcts/ccd-data-store-api,master,,,java11,,,,
 ,hmcts/ccd-definition-store-api,master,,,java8,,,,
 ,hmcts/ccd-user-profile-api,master,,,java8,,,,
 ,hmcts/cmc-claim-store,master,,,java8,,,,
@@ -19924,7 +19924,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,hortonworks/HA-Monitor,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,hortonworks/HBaseReplicationBridgeServer,master,maven,,java8,,,,
 ,hortonworks/ambari-rest-client,master,,,java8,,,,
-,hortonworks/cloudbreak,master,,,java8,,,,
+,hortonworks/cloudbreak,master,,,java11,,,,
 ,hortonworks/dstream,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,hortonworks/efm,CEM-1.0.0.0,,,java8,,,TRUE,Top-level build tool file is missing
 ,hortonworks/fieldeng-cronus,master,maven,,java8,,,,
@@ -20029,7 +20029,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,hubspot/dependency-scope-maven-plugin,master,maven,,java8,,,,
 ,hubspot/dropwizard-guice,master,maven,,java8,,,,
 ,hubspot/dropwizard-guicier,master,maven,,java8,,,,
-,hubspot/gcs-maven,master,maven,,java8,,,,
+,hubspot/gcs-maven,master,maven,,java11,,,,
 ,hubspot/guice-transactional,master,maven,,java8,,,,
 ,hubspot/httpQL,master,maven,,java8,,,,
 ,hubspot/hubspot-immutables,master,maven,,java8,,,,
@@ -20124,7 +20124,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,hyasinfosec/gitflow-gradle-plugin,develop,,,java8,,,,
 ,hyb1996/Auto.js,master,,,java8,,,,
 ,hyberbin/J-Excel,master,maven,,java8,,,,
-,hybridtechie/Date-Charts,master,,,java8,,,,
+,hybridtechie/Date-Charts,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,hydgladiator/cachecloud,master,maven,,java8,,,,
 ,hydgladiator/jedis,master,maven,,java8,,,,
 ,hydilois/iconlab,master,maven,,java8,,,,
@@ -20134,7 +20134,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,hyecheon/tasks,master,maven,,java8,,,,
 ,hyeong0113/registerForm,master,maven,,java8,,,,
 ,hygieia/ExecDashboard,master,maven,,java8,,,,
-,hygieia/api,master,maven,,java8,,,,
+,hygieia/api,master,maven,,java11,,,,
 ,hygieia/api-audit,master,maven,,java8,,,,
 ,hygieia/hygieia-api-karate-tests,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,hygieia/hygieia-apiaudit,main,maven,,java8,,,,
@@ -20181,7 +20181,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,hyperhq/hyper-commons-plugin,master,maven,,java8,,,,
 ,hyperhq/hyper-slaves-plugin,master,maven,,java8,,,,
 ,hyperion4040/Web-Service,master,maven,,java8,,,,
-,hyperlearningai/ontopop,develop,maven,,java8,,,,
+,hyperlearningai/ontopop,develop,maven,,java11,,,,
 ,hyperledger-labs/business-partner-agent,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,hyperledger-labs/hlf-connector,main,maven,,java8,,,,
 ,hyperledger/aries-sdk-java,main,maven,,java8,,,,
@@ -20239,7 +20239,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,iTitus/BCAMultiBlocks,master,,,java8,,,,
 ,iTitus/GimmeNBT,master,,,java8,,,,
 ,iTitus/GimmeStuff,master,,,java8,,,,
-,iTitus/PDXTools,main,,,java8,,,,
+,iTitus/PDXTools,main,,,java11,,,,
 ,iTitus/RecStat,1.11.x,,,java8,,,,
 ,iTitus/Sudoku,main,,,java8,,,,
 ,iTitus/TicTacToe,main,,,java8,,,,
@@ -20247,7 +20247,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,iTitus/commons,main,,,java8,,,,
 ,iTitus/factorio-recipes,main,,,java8,,,,
 ,iTitus/nbtviewer,main,,,java8,,,,
-,iTitus/skat-java,main,,,java8,,,,
+,iTitus/skat-java,main,,,java11,,,,
 ,iTitus/valve-tools,main,,,java8,,,,
 ,iZettle/android-html2bitmap,develop,,,java8,,,,
 ,ia-toki/judgels,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -20289,7 +20289,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,iarechaga/gameOfLife,master,maven,,java8,,,,
 ,iasper/jhipster-sample-application,master,maven,,java8,,,,
 ,iavael/EnableContactsGroups,develop,,,java8,,,,
-,ibaton/3House,develop,,,java8,,,,
+,ibaton/3House,develop,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,ibgithub/adaro6,master,maven,,java8,,,,
 ,ibgithub/ayogateway,master,maven,,java8,,,,
 ,ibgithub/spgserver,master,maven,,java8,,,,
@@ -20302,7 +20302,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ibm-messaging/mq-jms-spring,master,,,java8,,,,
 ,ibm-research-ireland/sparkoscope,master,maven,,java8,,,,
 ,ibm/GitIgnoreZipper,main,maven,,java8,,,,
-,ibm/JSONata4Java,master,maven,,java8,,,,
+,ibm/JSONata4Java,master,maven,,java11,,,,
 ,ibm/Lagom-Liberty-Kubernetes,master,maven,,java8,,,,
 ,ibm/TAT-Banking,main,maven,,java8,,,,
 ,ibm/acmeair-quarkus,main,maven,,java11,,,,
@@ -20398,7 +20398,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ibm/ram-guards,main,,,java8,,,,
 ,ibm/reactive-code-workshop,master,maven,,java8,,,,
 ,ibm/reactive-components,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
-,ibm/restconf-driver,master,maven,,java8,,,,
+,ibm/restconf-driver,master,maven,,java11,,,,
 ,ibm/scc-java-sdk,main,maven,,java8,,,,
 ,ibm/schematics-java-sdk,main,maven,,java8,,,,
 ,ibm/secrets-manager-java-sdk,main,maven,,java8,,,,
@@ -20535,7 +20535,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,iherasymenko/gradle-allure-plugin,master,,,java8,,,,
 ,iherasymenko/jlink-gradle-plugin,master,,,java11,,,,
 ,ihmcrobotics/ihmc-build,develop,,gradle,java8,,,,
-,ihmcrobotics/ihmc-cd,develop,,gradle,java8,,,,
+,ihmcrobotics/ihmc-cd,develop,,gradle,java17,,,,
 ,ihmcrobotics/ihmc-ci,develop,,gradle,java8,,,,
 ,ihmcrobotics/ihmc-java-ros2-communication,develop,,gradle,java8,,,,
 ,ihmcrobotics/log-tools,develop,,gradle,java8,,,,
@@ -20720,14 +20720,14 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,indrashekar/test,master,maven,,java8,,,,
 ,inductiveautomation/ignition-sdk-examples,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,indy256/codelibrary,master,,,java8,,,TRUE,Top-level build tool file is missing
-,indywidualny/FaceSlim,master,,,java8,,,,
+,indywidualny/FaceSlim,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,inesmamay/arbre-gta-application,master,maven,,java8,,,,
 ,infearOnTheWay/SimpleMsgApp,master,maven,,java8,,,,
 ,inferred/FreeBuilder,main,,,java8,,,,
 ,infinispan-demos/infinispan-wf-swarm-example,master,maven,,java8,,,,
 ,infinispan/Infinispan-book,master,maven,,java8,,,,
 ,infinispan/visual,main,maven,,java8,,,,
-,infinitum1984/MeWordsBot,master,maven,,java8,,,,
+,infinitum1984/MeWordsBot,master,maven,,java17,,,,
 ,infinum/Android-Goldfinger,master,,,java8,,,,
 ,infinum/Android-Prince-of-Versions,master,,,java8,,,,
 ,influxdata/influxdb-java,master,maven,,java8,,,,
@@ -20740,7 +20740,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,informatique-cdc/ebad,master,maven,,java8,,,,
 ,infoshareacademy/jjdz4-zolci-app,develop,maven,,java8,,,,
 ,infotec-fiware/green-orion,master,maven,,java8,,,,
-,infowangxin/sc,master,maven,,java8,,,,
+,infowangxin/sc,master,maven,,java17,,,,
 ,infowangxin/springmvc,master,maven,,java8,,,,
 ,infuq/dubbo-v2.6.9,master,maven,,java8,,,,
 ,ing-bank/ing-ideal-connectors-java,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -20821,10 +20821,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,intuit/Autumn,develop,maven,,java8,,,,
 ,intuit/QuickBooks-V3-Java-SDK,develop,maven,,java8,,,,
 ,intuit/QuickFabric,master,,,java8,,,TRUE,Top-level build tool file is missing
-,intuit/Tank,master,maven,,java8,,,,
+,intuit/Tank,master,maven,,java11,,,,
 ,intuit/benten,master,maven,,java8,,,,
 ,intuit/datum-ipsum,master,maven,,java8,,,,
-,intuit/fuzzy-matcher,master,maven,,java8,,,,
+,intuit/fuzzy-matcher,master,maven,,java11,,,,
 ,intuit/spring-config-client-fallback,master,maven,,java8,,,,
 ,intuit/wasabi,develop,maven,,java8,,,,
 ,inventit/processing-android-serial,master,maven,,java8,,,,
@@ -20863,7 +20863,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,iqiyi/Lens,master,,,java8,,,,
 ,iqiyi/Neptune,master,,,java8,,,,
 ,iqiyi/TaskManager,master,,,java8,,,,
-,iqiyi/dexSplitter,master,,,java8,,,,
+,iqiyi/dexSplitter,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,iqiyi/lotus,master,,,java8,,,,
 ,iqiyi/xHook,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,iqq-team/webqq-core,master,maven,,java8,,,,
@@ -20981,7 +20981,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,itowne/posmall,master,maven,,java8,,,,
 ,itruong/web-bot-public,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,its-arun/Mini-UMS-App,master,,,java8,,,,
-,its-danny/xibalba,master,,,java8,,,,
+,its-danny/xibalba,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,its4u/vestiary,main,maven,,java8,,,,
 ,itsallcode/openfasttrace-gradle,develop,,,java11,,,,
 ,itsgauravsaxena/demoapp,master,maven,,java8,,,,
@@ -21050,7 +21050,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,izpack/izpack,master,maven,,java8,,,,
 ,izumin5210/Droidux,master,,,java8,,,,
 ,j-crawford/uPortal,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
-,j-easy/easy-batch,master,maven,,java8,,,,
+,j-easy/easy-batch,master,maven,,java11,,,,
 ,j-easy/easy-random,master,maven,,java8,,,,
 ,j-easy/easy-rules,master,maven,,java8,,,,
 ,j-easy/easy-states,master,maven,,java8,,,,
@@ -21161,7 +21161,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jairosousa/Financeiro-2-0,master,maven,,java8,,,,
 ,jairosousa/scc-indicadores,master,maven,,java8,,,,
 ,jaiswalakshansh/Vuldroid,master,,,java8,,,TRUE,Top-level build tool file is missing
-,jakartaee/authentication,master,maven,,java8,,,,
+,jakartaee/authentication,master,maven,,java11,,,,
 ,jakartaee/authorization,master,maven,,java8,,,,
 ,jakartaee/cdi,master,maven,,java8,,,,
 ,jakartaee/concurrency,master,maven,,java8,,,,
@@ -21336,7 +21336,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,java110/MicroCommunity,master,maven,,java8,,,,
 ,java8/Java8InAction,master,maven,,java8,,,,
 ,java9-modularity/gradle-modules-plugin,master,,,java8,,,,
-,javaBin/cake-redux,master,maven,,java8,,,,
+,javaBin/cake-redux,master,maven,,java11,,,,
 ,javaZeus/mrp-project,master,maven,,java8,,,,
 ,javacc/javacc,master,maven,,java8,,,,
 ,javachaos/SolarTracer,master,maven,,java8,,,,
@@ -21379,7 +21379,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,javanna/elasticshell,master,maven,,java8,,,,
 ,javaparser/javaparser,master,,,java8,,,,
 ,javaparser/javasymbolsolver,master,,,java8,,,TRUE,Build uses Gradle 2.x
-,javasoze/clue,master,maven,,java8,,,,
+,javasoze/clue,master,maven,,java11,,,,
 ,javasoze/druid-lucene,master,maven,,java8,,,,
 ,javasoze/kamikaze,master,maven,,java8,,,,
 ,javastacks/javastack,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -21452,7 +21452,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jbehave/jbehave-core,master,maven,,java8,,,,
 ,jbehave/jbehave-tutorial,master,maven,,java8,,,,
 ,jbellis/jamm,master,,,java8,,,,
-,jberet/jsr352,master,maven,,java8,,,,
+,jberet/jsr352,master,maven,,java11,,,,
 ,jberkel/pay-me,master,maven,,java8,,,,
 ,jberkel/sms-backup-plus,master,,,java8,,,,
 ,jbernach/social-login,master,maven,,java8,,,,
@@ -21535,7 +21535,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jbosstools/jbosstools-forge,main,maven,,java8,,,,
 ,jbosstools/jbosstools-freemarker,master,maven,,java8,,,,
 ,jbosstools/jbosstools-maven-plugins,main,,,java8,,,TRUE,Top-level build tool file is missing
-,jbox2d/jbox2d,master,maven,,java8,,,,
+,jbox2d/jbox2d,master,maven,,java11,,,,
 ,jburwell/gradle-javarepl-plugin,master,,,java8,,,TRUE,Build uses Gradle 3.x
 ,jc-lab/gradle-cmake-plugin,master,,,java8,,,,
 ,jcabi/jcabi-aether,master,maven,,java8,,,,
@@ -21612,7 +21612,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jdarosTD/android-s3-plugin,master,,,java8,,,,
 ,jdarosTD/appcenter-publish-plugin,master,,,java8,,,,
 ,jdarosTD/boxfuse-variants,master,,,java8,,,,
-,jdbi/jdbi,master,maven,,java8,,,,
+,jdbi/jdbi,master,maven,,java11,,,,
 ,jdbonfils/JEE-Limcoins,master,maven,,java8,,,,
 ,jdcasey/markdown4j,master,maven,,java8,,,,
 ,jdeferred/jdeferred,master,,,java8,,,,
@@ -21622,7 +21622,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jdelker/redistjar-maven-plugin,master,maven,,java8,,,,
 ,jdemetra/jdemetra-app,develop,maven,,java8,,,,
 ,jdemetra/jdemetra-core,develop,maven,,java8,,,,
-,jdereg/java-util,master,maven,,java8,,,,
+,jdereg/java-util,master,maven,,java11,,,,
 ,jderuiter/javacard-openpgpcard,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,jdewinne/spring-petclinic,master,maven,,java8,,,,
 ,jdfind/gradle-spoon-plugin,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
@@ -21678,7 +21678,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jeequan/jeepay,master,maven,,java8,,,,
 ,jeevatkm/digitalocean-api-java,master,maven,,java8,,,,
 ,jefersonmombach/ducarmolocacoes,master,maven,,java8,,,,
-,jeffbuonamici/k9mail,master,,,java8,,,,
+,jeffbuonamici/k9mail,master,,,java8,,,TRUE,Gradle wrapper 4.7 is not supported
 ,jeffdcamp/dbtools-gen,master,,,java8,,,,
 ,jeffheaton/encog-java-core,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,jeffheaton/encog-java-examples,master,,,java8,,,,
@@ -21724,9 +21724,9 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jemand771/jenkins-test,master,maven,,java8,,,,
 ,jemand771/msatest,master,maven,,java8,,,,
 ,jenetics/jenetics,master,,,java8,,,,
-,jenetics/jpx,master,,,java8,,,,
+,jenetics/jpx,master,,,java17,,,,
 ,jenetics/medimg,master,,,java8,,,,
-,jenetics/prngine,master,,,java8,,,,
+,jenetics/prngine,master,,,java11,,,,
 ,jenkins-docs/simple-java-maven-app,master,maven,,java8,,,,
 ,jenkins-infra/.github,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,jenkins-infra/INFRA-896,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -21782,7 +21782,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jenkins-infra/incrementals-publisher,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,jenkins-infra/infra-reports,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,jenkins-infra/interesting-category-action,main,,,java8,,,TRUE,Top-level build tool file is missing
-,jenkins-infra/ircbot,main,maven,,java8,,,,
+,jenkins-infra/ircbot,main,maven,,java11,,,,
 ,jenkins-infra/java.net-scm-issue-link,master,maven,,java8,,,,
 ,jenkins-infra/javadoc,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,jenkins-infra/jenkins-codeql,main,,,java8,,,TRUE,Top-level build tool file is missing
@@ -23416,7 +23416,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jenly1314/KingKeyboard,master,,,java8,,,,
 ,jenly1314/MVVMFrame,master,,,java8,,,,
 ,jenly1314/SlideBar,master,,,java8,,,,
-,jenly1314/ZXingLite,master,,,java8,,,,
+,jenly1314/ZXingLite,master,,,java11,,,,
 ,jennypherroussell/jhipster-sample-application,master,maven,,java8,,,,
 ,jensalm/spring-rest-server,master,maven,,java8,,,,
 ,jensim/kt2ts-gradle-plugin,master,,,java8,,,,
@@ -23471,7 +23471,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jexp/jpatterns,master,maven,,java8,,,,
 ,jexp/neo4j-shell-tools,3,maven,,java8,,,,
 ,jexp/store-utils,3.5,maven,,java8,,,,
-,jexxa-projects/AddendJ,master,maven,,java8,,,,
+,jexxa-projects/AddendJ,master,maven,,java11,,,,
 ,jexxa-projects/Jexxa,master,maven,,java8,,,,
 ,jezhumble/javasysmon,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,jfabianquevedo/CargaMasiva,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -23488,10 +23488,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jfoenixadmin/JFoenix,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,jfontignie/TreasureHunt,master,maven,,java8,,,,
 ,jfree/jcommon,master,maven,,java8,,,,
-,jfree/jfreechart,master,maven,,java8,,,,
+,jfree/jfreechart,master,maven,,java11,,,,
 ,jfree/jfreechart-fse,master,maven,,java8,,,,
 ,jfree/jfreesvg,master,maven,,java8,,,,
-,jfriesse/k-9-hacked,master,,,java8,,,,
+,jfriesse/k-9-hacked,master,,,java8,,,TRUE,Gradle wrapper 4.5.1 is not supported
 ,jfrog/artifactory-cli-java-deprecated,master,maven,,java8,,,,
 ,jfrog/artifactory-client-java,master,,,java8,,,,
 ,jfrog/artifactory-maven-plugin,master,maven,,java8,,,,
@@ -23501,7 +23501,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jfrog/file-specs-java,main,,,java8,,,,
 ,jfrog/ide-plugins-common,master,,,java8,,,,
 ,jfrog/jfrog-eclipse-plugin,master,maven,,java8,,,,
-,jfrog/jfrog-idea-plugin,master,,,java8,,,,
+,jfrog/jfrog-idea-plugin,master,,,java11,,,,
 ,jfrog/jfrog-pipelines-maven-sample,master,maven,,java8,,,,
 ,jfrog/jfrog-pipelines-steps-examples,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,jfrog/jfrog-testing-infra,main,,,java8,,,TRUE,Top-level build tool file is missing
@@ -23511,7 +23511,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jfullam/jenkins-application-director,master,maven,,java8,,,,
 ,jgarzonp/clients-web,master,maven,,java8,,,,
 ,jgasmi/jhipster-mt,master,maven,,java8,,,,
-,jgerhards/SLFA,master,,,java8,,,,
+,jgerhards/SLFA,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,jghoman/finagle-java-example,master,maven,,java8,,,,
 ,jghoman/haivvreo,master,maven,,java8,,,,
 ,jgilfelt/SystemBarTint,master,,,java8,,,,
@@ -23567,7 +23567,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jhipster-latino/coverb-demo-react,master,maven,,java8,,,,
 ,jhipster/devoxx-2016,master,maven,,java8,,,,
 ,jhipster/jhipster,main,maven,,java8,,,,
-,jhipster/jhipster-bom,main,maven,,java11,,,,
+,jhipster/jhipster-bom,main,maven,,java17,,,,
 ,jhipster/jhipster-lite,main,maven,,java17,,,,
 ,jhipster/jhipster-loaded,master,maven,,java8,,,,
 ,jhipster/jhipster-neo4j-app,master,maven,,java8,,,,
@@ -23624,7 +23624,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jianainvsheng/-,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,jiang-30/demo-cloud,main,maven,,java8,,,,
 ,jiang111/IndexRecyclerView,master,,,java8,,,,
-,jiang111/IndicatorDialog,master,,,java8,,,,
+,jiang111/IndicatorDialog,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,jiangboh/ScannerController,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,jiangdongguo/AndroidUSBCamera,master,,,java8,,,,
 ,jianghejie/XRecyclerView,master,,,java8,,,TRUE,Build uses Gradle 2.x
@@ -23693,20 +23693,20 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jitsi/ice4j,master,maven,,java8,,,,
 ,jitsi/jibri,master,maven,,java8,,,,
 ,jitsi/jicoco,master,maven,,java8,,,,
-,jitsi/jicofo,master,maven,,java8,,,,
-,jitsi/jigasi,master,maven,,java8,,,,
+,jitsi/jicofo,master,maven,,java11,,,,
+,jitsi/jigasi,master,maven,,java11,,,,
 ,jitsi/jitsi,master,maven,,java8,,,,
-,jitsi/jitsi-android-osgi,master,maven,,java8,,,,
+,jitsi/jitsi-android-osgi,master,maven,,java11,,,,
 ,jitsi/jitsi-gpl-dependencies,master,maven,,java8,,,,
 ,jitsi/jitsi-lgpl-dependencies,master,maven,,java8,,,,
 ,jitsi/jitsi-media-transform,master,,,java8,,,TRUE,Top-level build tool file is missing
-,jitsi/jitsi-meet-torture,master,maven,,java8,,,,
+,jitsi/jitsi-meet-torture,master,maven,,java11,,,,
 ,jitsi/jitsi-rtp,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,jitsi/jitsi-sctp,master,maven,,java8,,,,
 ,jitsi/jitsi-srtp,master,maven,,java8,,,,
 ,jitsi/jitsi-stats,master,maven,,java8,,,,
 ,jitsi/jitsi-utils,master,maven,,java11,,,,
-,jitsi/jitsi-videobridge,master,maven,,java8,,,,
+,jitsi/jitsi-videobridge,master,maven,,java11,,,,
 ,jitsi/jitsi-videobridge-openfire-plugin,master,maven,,java8,,,,
 ,jitsi/jitsi-xmpp-extensions,master,maven,,java8,,,,
 ,jitsi/jsocks,master,maven,,java8,,,,
@@ -23747,7 +23747,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jjzhang166/XBaseAndroid,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,jk1/Gradle-License-Report,master,,,java11,,,,
 ,jk1/TeamCity-dependencies-gradle-plugin,master,,,java8,,,,
-,jkazama/ddd-java,master,,,java8,,,,
+,jkazama/ddd-java,master,,,java17,,,,
 ,jkdntc/cmpp,master,,,java8,,,,
 ,jkennedy1980/Objective-C-CPD-Language,master,maven,,java8,,,,
 ,jkiddo/gmusic.api,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -23853,7 +23853,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jmurty/java-xmlbuilder,master,maven,,java8,,,,
 ,jmxtrans/embedded-jmxtrans,master,maven,,java8,,,,
 ,jmxtrans/jmxtrans,master,maven,,java8,,,,
-,jmxtrans/jmxtrans-agent,master,maven,,java8,,,,
+,jmxtrans/jmxtrans-agent,master,maven,,java11,,,,
 ,jneat/mybatis-types,master,,,java8,,,,
 ,jnewc/github-coverage-reporter,master,maven,,java8,,,,
 ,jnicolas007/BoutikPam,master,maven,,java8,,,,
@@ -23884,7 +23884,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jobmission/oauth2-server,master,maven,,java8,,,,
 ,jobop/anylog,master,maven,,java8,,,,
 ,jobplanet/elasticsearch-twitter-korean,master,maven,,java8,,,,
-,jobrunr/jobrunr,master,,,java8,,,,
+,jobrunr/jobrunr,master,,,java11,,,,
 ,jobykorahwizroots/wizroots,master,maven,,java8,,,,
 ,jochenberger/gradle-lein,master,,,java8,,,TRUE,Build uses Gradle 3.x
 ,jochenseeber/gradle-bintray-config,master,,,java8,,,,
@@ -24012,7 +24012,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jonsychen/admin,master,maven,,java8,,,,
 ,jooby-project/jooby,2.x,maven,,java8,,,,
 ,jopengroup/android-gooview,master,,,java8,,,,
-,jopt-simple/jopt-simple,master,maven,,java8,,,,
+,jopt-simple/jopt-simple,master,maven,,java11,,,,
 ,jordenLwq/redisson,master,maven,,java8,,,,
 ,jordiferm/softtopia-web-spring,master,maven,,java8,,,,
 ,jordifierro/android-base,master,,,java8,,,,
@@ -24154,7 +24154,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jruby-gradle/jruby-gradle-plugin,master,,,java8,,,,
 ,jruby-gradle/jruby-gradle-storm-plugin,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,jruby/activerecord-jdbc-adapter,master,maven,,java8,,,,
-,jruby/dirgra,master,maven,,java8,,,,
+,jruby/dirgra,master,maven,,java11,,,,
 ,jruby/joni,master,maven,,java8,,,,
 ,jruby/jruby,master,maven,,java8,,,,
 ,jruby/jruby-openssl,master,maven,,java8,,,,
@@ -24200,7 +24200,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jsvitak/jbpm-workflow-plugin,master,maven,,java8,,,,
 ,jsyGitTest/jmm,master,maven,,java8,,,,
 ,jszczygiel/AndroidYoutubeOverlay,master,,,java8,,,,
-,jtablesaw/tablesaw,master,maven,,java8,,,,
+,jtablesaw/tablesaw,master,maven,,java11,,,,
 ,jtalbo/jhipster-association-gasnier,master,maven,,java8,,,,
 ,jtarrio/debloat,master,maven,,java8,,,,
 ,jtlai0921/JavaCourse,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -24594,7 +24594,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,kbastani/spring-cloud-microservice-example,master,maven,,java8,,,,
 ,kbriggs/jenkins-git-chooser-alternative-plugin,master,maven,,java8,,,,
 ,kbrownnn/wmss,master,,,java8,,,TRUE,Top-level build tool file is missing
-,kbss-cvut/termit,master,maven,,java8,,,,
+,kbss-cvut/termit,master,maven,,java11,,,,
 ,kchojhu/jhipster-app,master,maven,,java8,,,,
 ,kckane/dynamic-axis-plugin,master,maven,,java8,,,,
 ,kcloss/gradle-bluej-jar,main,,,java8,,,,
@@ -24650,7 +24650,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,kemuri-9/gradle-plugin-mrjar,main,,,java8,,,,
 ,kenancb/SNS,master,maven,,java8,,,,
 ,kenchandev/Bike-Sync,master,,,java8,,,TRUE,Top-level build tool file is missing
-,kenglxn/QRGen,master,maven,,java8,,,,
+,kenglxn/QRGen,master,maven,,java11,,,,
 ,kengu/gwt-leaflet,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,kenhiti/ProjetoIntegradorII,master,maven,,java8,,,,
 ,kenhuri/demo2,master,maven,,java8,,,,
@@ -24757,7 +24757,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,kiegroup/kie-soup,main,maven,,java8,,,,
 ,kiegroup/kie-wb-common,main,maven,,java8,,,,
 ,kiegroup/kogito-examples,stable,,,java11,,,,
-,kiegroup/kogito-runtimes,main,,,java8,,,,
+,kiegroup/kogito-runtimes,main,,,java11,,,,
 ,kiegroup/optaplanner,main,maven,,java11,,,,
 ,kiegroup/optaweb-employee-rostering,main,maven,,java11,,,,
 ,kiegroup/optaweb-vehicle-routing,main,,,java11,,,,
@@ -24782,7 +24782,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,killme2008/xmemcached,master,maven,,java8,,,,
 ,killuazhu/around,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,kiluyaqing/proxy,master,maven,,java8,,,,
-,kim709394/java-demo,master,maven,,java8,,,,
+,kim709394/java-demo,master,maven,,java11,,,,
 ,kimble/gradle-task-profiling-plugin,master,,gradle,java8,,,,
 ,kimifdw/LearnJava,master,maven,,java8,,,,
 ,kimifdw/multithreading-project,master,,,java8,,,,
@@ -24801,7 +24801,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,king-zyd/core,master,maven,,java8,,,,
 ,king/king-http-client,master,,,java8,,,,
 ,kingBook/cross-2.1.5,master,,,java8,,,TRUE,Top-level build tool file is missing
-,kingjon3377/tartan-gui,master,maven,,java8,,,,
+,kingjon3377/tartan-gui,master,maven,,java17,,,,
 ,kingofglory/EasyPay,master,,,java8,,,,
 ,kingofmorning/chongba,master,maven,,java8,,,,
 ,kingschan1204/istock,develop,maven,,java8,,,,
@@ -24906,7 +24906,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,kmiakisz/flowerApp,master,maven,,java8,,,,
 ,kmoloniewicz/dashboard-vaadin,master,maven,,java8,,,,
 ,kmshack/Android-TopScrollHelper,master,,,java8,,,,
-,knaufk/flink-faker,master,maven,,java8,,,,
+,knaufk/flink-faker,master,maven,,java11,,,,
 ,kncept/junit-reporter,master,,,java8,,,,
 ,kndiaye/BrainToc,master,,,java8,,,,
 ,kndlr/IsRand,master,maven,,java8,,,,
@@ -24920,7 +24920,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,knopflerfish/knopflerfish.org,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,knowm/Sundial,develop,maven,,java8,,,,
 ,knowm/XChange,develop,maven,,java8,,,,
-,knowm/XChart,develop,maven,,java8,,,,
+,knowm/XChart,develop,maven,,java11,,,,
 ,knowm/Yank,develop,maven,,java8,,,,
 ,knowm/dropwizard-sundial,master,maven,,java8,,,,
 ,knutwalker/netty-vbuf,master,maven,,java8,,,,
@@ -24993,11 +24993,11 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,konzip222/Apka,master,maven,,java8,,,,
 ,koolanky/activti-starter,master,maven,,java8,,,,
 ,koolskateguy89/Anime-Filler-Manager,main,maven,,java8,,,,
-,koolskateguy89/Mobile-OS,main,maven,,java8,,,,
+,koolskateguy89/Mobile-OS,main,maven,,java11,,,,
 ,koply/Botanic,master,maven,,java8,,,,
 ,koply/KCommando,master,maven,,java8,,,,
 ,koply/queststore,main,maven,,java8,,,,
-,koraktor/mavanagaiata,master,maven,,java8,,,,
+,koraktor/mavanagaiata,master,maven,,java11,,,,
 ,koraktor/steam-condenser-java,master,maven,,java8,,,,
 ,koral--/android-animation-disabler,master,,,java8,,,,
 ,koral--/android-gif-drawable,dev,,,java11,,,,
@@ -25035,7 +25035,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,kotest/kotest,master,,,java8,,,,
 ,kotlinx/ast,master,,,java8,,,,
 ,kotvertolet/youtube-jextractor,master,,,java8,,,,
-,kouami/ldapcrudweb,master,,,java8,,,,
+,kouami/ldapcrudweb,master,,,java8,,,TRUE,Gradle wrapper 4.5.1 is not supported
 ,kousen/java_8_recipes,master,,,java8,,,,
 ,kousen/java_upgrade,main,,,java8,,,,
 ,koush/AndroidAsync,master,,,java8,,,TRUE,Error: Could not find or load main class org.gradle.wrapper.GradleWrapperMain (gradlew present but wrapper jar missing)
@@ -25050,7 +25050,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,kp-marczynski/seriesapp,master,maven,,java8,,,,
 ,kpavlov/fixio,master,maven,,java8,,,,
 ,kpavlov/jreactive-8583,master,,,java8,,,,
-,kpavlov/netty-jaxrs,master,maven,,java8,,,,
+,kpavlov/netty-jaxrs,master,maven,,java11,,,,
 ,kpelykh/docker-java,master,maven,,java8,,,,
 ,kpramesh2212/json2java-gradle-plugin,main,,,java8,,,,
 ,kpramesh2212/openapi-merger-plugin,main,,,java8,,,,
@@ -25221,7 +25221,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ktorio/ktor,main,,,java8,,,,
 ,ktrof/nirma-geoservice,master,maven,,java8,,,,
 ,ktt-ol/hacs,master,,,java8,,,,
-,ktuukkan/marine-api,master,maven,,java8,,,,
+,ktuukkan/marine-api,master,maven,,java11,,,,
 ,ktvcv/azure-function,master,maven,,java8,,,,
 ,ktyminski/jeeSpring,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,kuaixingyi/Graduation-project-pro,main,maven,,java8,,,,
@@ -25266,7 +25266,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,kuvic16/snowflake,master,maven,,java8,,,,
 ,kuyue/WeChatPublishImagesDrag,master,,,java8,,,,
 ,kuzank/SpringBlade-QuickStart,2.0-boot,maven,,java8,,,,
-,kuzzleio/sdk-android,master,,,java8,,,,
+,kuzzleio/sdk-android,master,,,java8,,,TRUE,Gradle wrapper 4.9 is not supported
 ,kuzzleio/sdk-java,master,,,java8,,,,
 ,kv2014/oa,master,maven,,java8,,,,
 ,kvigulis/Java-DIY-Multithread-server-with-webpage,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -25281,7 +25281,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,kyleduo/SwitchButton,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,kylekapsch/g3cm,master,maven,,java8,,,,
 ,kylepls/mcspring,master,maven,,java8,,,,
-,kylin0925/G2048,master,,,java8,,,,
+,kylin0925/G2048,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,kylixs/flare-profiler,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,kymjs/Contacts,master,,,java8,,,,
 ,kymjs/EmojiChat,master,,,java8,,,,
@@ -25291,7 +25291,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,kyriakoschr/eCommerceApp,master,maven,,java8,,,,
 ,kyze8439690/ResideLayout,master,,gradle,java8,,,,
 ,kyze8439690/RevealLayout,master,,gradle,java8,,,,
-,kzaikin/test-smells,master,,,java8,,,,
+,kzaikin/test-smells,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,kzn/rome-old,master,maven,,java8,,,,
 ,kzonix/firecall-flex-apio,master,,gradle,java8,,,,
 ,kzwang/elasticsearch-image,master,maven,,java8,,,,
@@ -25342,8 +25342,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,laidu823/alpha,master,maven,,java8,,,,
 ,laiyuchenrushuang/MD5_more,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,lakidateam/lkdcrm-maven,master,maven,,java8,,,,
-,lakinduakash/MathTutor,master,,,java8,,,,
-,lakinduakash/MyPartner,master,,,java8,,,,
+,lakinduakash/MathTutor,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
+,lakinduakash/MyPartner,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,lakinduakash/javaFxUniversityPortal,master,,,java8,,,,
 ,lakinduakash/mi-band-hr-monitor,master,,,java8,,,,
 ,lakinduakash/test-vid-stable,master,,,java8,,,,
@@ -25467,7 +25467,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,leMedi/GestionDeCommandesSpringAngular,master,maven,,java8,,,,
 ,leadDirec/flink-stream,master,maven,,java8,,,,
 ,lealceldeiro/gms,master,,,java8,,,TRUE,Top-level build tool file is missing
-,lealone/Lealone,master,maven,,java8,,,,
+,lealone/Lealone,master,maven,,java11,,,,
 ,leancloud/LeanCloudChatKit-Android,master,,,java8,,,,
 ,leancloud/android-push-demo,master,,,java8,,,,
 ,leancloud/java-sdk,master,maven,,java8,,,,
@@ -25494,7 +25494,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,leeadkins/elasticsearch-redis-river,master,maven,,java8,,,,
 ,leebake/MOP,master,maven,,java8,,,,
 ,leechenxiang/imooc-springboot-starter,master,maven,,java8,,,,
-,leedo1982/object,main,maven,,java8,,,,
+,leedo1982/object,main,maven,,java11,,,,
 ,leelit/STUer-client,master,,,java8,,,,
 ,leelokas/vacation_tracker,master,maven,,java8,,,,
 ,leelovejava/cloud2020,master,maven,,java8,,,,
@@ -25530,7 +25530,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,lemire/CompressWikipediaAsIntegerVectors,master,maven,,java8,,,,
 ,lemire/HashVSTree,master,maven,,java8,,,,
 ,lemire/IndexWikipedia,master,maven,,java8,,,,
-,lemire/JavaFastPFOR,master,maven,,java8,,,,
+,lemire/JavaFastPFOR,master,maven,,java11,,,,
 ,lemire/RoaringBitmapReal,master,maven,,java8,,,,
 ,lemire/RoaringBitmapSynth,master,maven,,java8,,,,
 ,lemire/RoaringVSConciseBenchmark,master,maven,,java8,,,,
@@ -25549,7 +25549,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,lennartkoopmann/nzyme,master,maven,,java8,,,,
 ,lensesio/kafka-connect-query-language,master,,,java8,,,,
 ,lensesio/stream-reactor,master,,,java8,,,TRUE,Top-level build tool file is missing
-,lenskit/lenskit,master,,,java8,,,,
+,lenskit/lenskit,master,,,java8,,,TRUE,Gradle wrapper 4.8 is not supported
 ,lenve/VBlog,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,lenve/vhr,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,leo-he/microserviceGateway,master,maven,,java8,,,,
@@ -25640,7 +25640,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,lgj123456/MadNote,master,,,java8,,,,
 ,lgorczynski98/JARcheatEngine,master,maven,,java8,,,,
 ,lgren/xdiamond-rootpom,master,maven,,java8,,,,
-,lgs-games/eden,main,,,java8,,,,
+,lgs-games/eden,main,,,java11,,,,
 ,lgtm-test-repos/basic,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,lgtm-test-repos/pull-request,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,lgtm-test-repos/suppression,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -25759,8 +25759,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,lightertu/NetsecIoT,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,lightless233/Java-Unserialization-Study,master,maven,,java8,,,,
 ,lightningMan/flash-netty,master,maven,,java8,,,,
-,ligi/FAST,master,,,java8,,,,
-,ligi/PassAndroid,master,,,java8,,,,
+,ligi/FAST,master,,,java8,,,TRUE,Gradle wrapper 4.9 is not supported
+,ligi/PassAndroid,master,,,java11,,,,
 ,ligol/IconicsFontGenerator,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,lihangleo2/ShadowLayout,master,,,java8,,,,
 ,lihengming/java-codes,master,maven,,java8,,,,
@@ -25847,7 +25847,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,linkedin/avro-util,master,,,java8,,,,
 ,linkedin/brooklin,master,,,java8,,,,
 ,linkedin/coral,master,,,java8,,,,
-,linkedin/cruise-control,migrate_to_kafka_2_4,,,java8,,,,
+,linkedin/cruise-control,migrate_to_kafka_2_4,,,java11,,,,
 ,linkedin/databus,master,,gradle,java8,,,,
 ,linkedin/datahub,master,,,java8,,,,
 ,linkedin/datahub-gma,master,,,java8,,,,
@@ -26002,7 +26002,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,liuwill/spring-boot-pdf,master,,gradle,java8,,,,
 ,liuxixiang/yidian,master,,,java8,,,,
 ,liuxx-u/bird-java,master,maven,,java8,,,,
-,liuyangbajin/Performance,master,,,java8,,,,
+,liuyangbajin/Performance,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,liuyanggithub/SuperMvp,master,,,java8,,,,
 ,liuyangming/ByteTCC,master,maven,,java8,,,,
 ,liuyangming/ByteTCC-sample,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -26096,7 +26096,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,lobbin/tapestry-spring-security,master,maven,,java8,,,,
 ,lobfredd/Java-Enterprise-1,Eksamen,maven,,java8,,,,
 ,lobmarib/store,master,maven,,java8,,,,
-,locationtech/geogig,master,maven,,java8,,,,
+,locationtech/geogig,master,maven,,java11,,,,
 ,locationtech/jts,master,maven,,java8,,,,
 ,locationtech/spatial4j,master,maven,,java8,,,,
 ,lochnessdragon/DataFixerUpperExamples,master,,,java8,,,,
@@ -26185,7 +26185,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,lorisdanto/symbolicautomata,master,maven,,java8,,,,
 ,lorzab/myProject,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,loserdog-err/PlayTogether,master,,,java8,,,,
-,lostizalith/velka,master,maven,,java8,,,,
+,lostizalith/velka,master,maven,,java11,,,,
 ,lostzen/lost,master,,,java8,,,,
 ,lothrimondWDZ/nscanner,master,maven,,java8,,,,
 ,lotu-us/usedbook_v2,main,,,java8,,,,
@@ -26490,8 +26490,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,m8100213721/diane,master,maven,,java8,,,,
 ,mP1/j2cl-java-io,master,maven,,java8,,,,
 ,mP1/j2cl-java-net,master,maven,,java8,,,,
-,mP1/j2cl-java-net-http,master,maven,,java8,,,,
-,mP1/j2cl-java-text,master,maven,,java8,,,,
+,mP1/j2cl-java-net-http,master,maven,,java11,,,,
+,mP1/j2cl-java-text,master,maven,,java11,,,,
 ,mP1/j2cl-java-text-annotation-processor,master,maven,,java8,,,,
 ,mP1/j2cl-java-util-Base64,master,maven,,java8,,,,
 ,mP1/j2cl-java-util-Calendar,master,maven,,java8,,,,
@@ -26502,16 +26502,16 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mP1/j2cl-java-util-TimeZone-annotation-processor,master,maven,,java8,,,,
 ,mP1/j2cl-java-util-currency-annotation-processor,master,maven,,java8,,,,
 ,mP1/j2cl-java-util-timezone-ZoneRulesReader,master,maven,,java8,,,,
-,mP1/j2cl-locale,master,maven,,java8,,,,
-,mP1/j2cl-maven-plugin,master,maven,,java8,,,,
-,mP1/walkingkooka,master,maven,,java8,,,,
+,mP1/j2cl-locale,master,maven,,java11,,,,
+,mP1/j2cl-maven-plugin,master,maven,,java11,,,,
+,mP1/walkingkooka,master,maven,,java11,,,,
 ,mP1/walkingkooka-color,master,maven,,java8,,,,
-,mP1/walkingkooka-convert,master,maven,,java8,,,,
+,mP1/walkingkooka-convert,master,maven,,java11,,,,
 ,mP1/walkingkooka-datetime,master,maven,,java8,,,,
 ,mP1/walkingkooka-emulator-c64,master,maven,,java8,,,,
 ,mP1/walkingkooka-java-shader,master,maven,,java8,,,,
 ,mP1/walkingkooka-math,master,maven,,java8,,,,
-,mP1/walkingkooka-net,master,maven,,java8,,,,
+,mP1/walkingkooka-net,master,maven,,java11,,,,
 ,mP1/walkingkooka-net-header-apache-tika,master,maven,,java8,,,,
 ,mP1/walkingkooka-net-http-client,master,maven,,java8,,,,
 ,mP1/walkingkooka-net-http-json,master,maven,,java8,,,,
@@ -26520,7 +26520,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mP1/walkingkooka-net-http-server-jetty,master,maven,,java8,,,,
 ,mP1/walkingkooka-resource,master,maven,,java8,,,,
 ,mP1/walkingkooka-resource-annotation-processor,master,maven,,java8,,,,
-,mP1/walkingkooka-route,master,maven,,java8,,,,
+,mP1/walkingkooka-route,master,maven,,java11,,,,
 ,mP1/walkingkooka-spreadsheet,master,maven,,java8,,,,
 ,mP1/walkingkooka-spreadsheet-expression-function,master,maven,,java8,,,,
 ,mP1/walkingkooka-spreadsheet-server,master,maven,,java8,,,,
@@ -26533,7 +26533,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mP1/walkingkooka-text-cursor-parser-ebnf-charpredicate,master,maven,,java8,,,,
 ,mP1/walkingkooka-text-pretty,master,maven,,java8,,,,
 ,mP1/walkingkooka-text-printer,master,maven,,java8,,,,
-,mP1/walkingkooka-tree,master,maven,,java8,,,,
+,mP1/walkingkooka-tree,master,maven,,java11,,,,
 ,mP1/walkingkooka-tree-expression-function-boolean,master,maven,,java8,,,,
 ,mP1/walkingkooka-tree-expression-function-datetime,master,maven,,java8,,,,
 ,mP1/walkingkooka-tree-expression-function-engineering,master,maven,,java8,,,,
@@ -26599,7 +26599,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mafidul/ins-str-employer-api,main,maven,,java8,,,,
 ,mafuhua/jhipsterSampleApplication,master,maven,,java8,,,,
 ,magarena/magarena,master,,,java8,,,TRUE,Top-level build tool file is missing
-,magasea/be-zcc,master,maven,,java8,,,,
+,magasea/be-zcc,master,maven,,java11,,,,
 ,magcode/sunricher-wifi-mqtt,master,maven,,java8,,,,
 ,magdaka13/MaSMSestro,master,,,java8,,,,
 ,mageddo/gradle-embed-maven-repo,master,,gradle,java8,,,,
@@ -26682,7 +26682,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,making/rsc,master,maven,,java8,,,,
 ,making/yavi,develop,maven,,java8,,,,
 ,makis90/VisionItBoard-V0.1,master,maven,,java8,,,,
-,makkarpov/mtoxy,master,,,java8,,,,
+,makkarpov/mtoxy,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,makotogo/developerWorks,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,makovkastar/FloatingActionButton,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,maks/MGit,master,,,java8,,,,
@@ -26751,7 +26751,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mannodermaus/retrofit-logansquare,master,,,java8,,,,
 ,mannyrivera2010/barium,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,manoelcyreno/selenium-commons,master,,,java8,,,,
-,manoelmerlin/estudo-java,main,maven,,java8,,,,
+,manoelmerlin/estudo-java,main,maven,,java17,,,,
 ,manoharanRajesh/jhipster-test-app,master,maven,,java8,,,,
 ,manoj-mass/Blog-JAVA-ANGULAR,master,maven,,java8,,,,
 ,manojbhadane/GenericAdapter,master,,,java8,,,,
@@ -26762,7 +26762,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,manojrpatil/jhipster_demo,master,maven,,java8,,,,
 ,manojsingh3889/JMS,master,maven,,java8,,,,
 ,manolo/Gradle-Sauce-Connect-Plugin,master,,,java8,,,,
-,manorrock/calico,current,maven,,java8,,,,
+,manorrock/calico,current,maven,,java17,,,,
 ,manosbatsis/gradle-reflections-plugin,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,mansikataria/Coolcook,master,maven,,java8,,,,
 ,manuel-freire/ac2,master,maven,,java8,,,,
@@ -26806,8 +26806,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,marcio81/BirringPosgres,master,maven,,java8,,,,
 ,marciorpda/jhipsterSampleApplication,master,maven,,java8,,,,
 ,marcluque/Hydra,master,maven,,java8,,,,
-,marcluque/Reversi-AI,master,maven,,java8,,,,
-,marcluque/TicTacToe-AI,master,maven,,java8,,,,
+,marcluque/Reversi-AI,master,maven,,java11,,,,
+,marcluque/TicTacToe-AI,master,maven,,java11,,,,
 ,marcmec/CRUD-JavaJsf,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,marcoRS/rxjava-essentials,master,,,java8,,,,
 ,marcoacribeiro/REFERENCEMODEL,master,maven,,java8,,,,
@@ -26917,13 +26917,13 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,martinmarinov/AndroidDvbDriver,master,,,java8,,,,
 ,martino2k6/StoreBox,master,,,java8,,,,
 ,martinpaljak/AppletPlayground,master,,,java8,,,TRUE,Top-level build tool file is missing
-,martinpaljak/EstEID,master,maven,,java8,,,,
+,martinpaljak/EstEID,master,maven,,java11,,,,
 ,martinpaljak/GlobalPlatformPro,master,maven,,java8,,,,
 ,martinpaljak/ant-javacard,master,maven,,java8,,,,
-,martinpaljak/apdu4j,master,maven,,java8,,,,
+,martinpaljak/apdu4j,master,maven,,java11,,,,
 ,martinpaljak/capfile,master,maven,,java8,,,,
-,martinpaljak/cdoc,master,maven,,java8,,,,
-,martinpaljak/cdoc4j,master,maven,,java8,,,,
+,martinpaljak/cdoc,master,maven,,java11,,,,
+,martinpaljak/cdoc4j,master,maven,,java11,,,,
 ,martinpaljak/esteid-sk,master,maven,,java8,,,,
 ,martinsam16/faas,main,maven,,java8,,,,
 ,martinschneider/justtestlah,master,maven,,java8,,,,
@@ -27016,7 +27016,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,matsuyoido/gradle-ER-plugin,master,,,java8,,,,
 ,matsuyoido/gradle-frontend-plugin,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,matsuyoido/gradle-md-plugin,master,,,java8,,,,
-,mattbdean/JRAW,master,,,java8,,,,
+,mattbdean/JRAW,master,,,java8,,,TRUE,Gradle wrapper 4.7 is not supported
 ,mattbertolini/CamClient,master,maven,,java8,,,,
 ,mattbertolini/spring-annotated-web-data-binder,main,,,java8,,,,
 ,mattdesimone444/golfHipster,master,maven,,java8,,,,
@@ -27058,7 +27058,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mauricioaniche/codesheriff,main,maven,,java8,,,,
 ,mauriciocatharino/BestMeal,master,maven,,java8,,,,
 ,mauriciofcesteves/study-spring-rest-angularjs,master,maven,,java8,,,,
-,mauriciogior/open-qrcode,master,,,java8,,,,
+,mauriciogior/open-qrcode,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,mauriciojerez/examen,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,mauricioriera/latesi,master,maven,,java8,,,,
 ,mauriciotogneri/green-coffee,master,,,java8,,,,
@@ -27086,7 +27086,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,maximelebastard/GLI-tp-2048,master,maven,,java8,,,,
 ,maximelebastard/TaskManager-TP-Spring,master,maven,,java8,,,,
 ,maximelebastard/vv-TP1,master,maven,,java8,,,,
-,maximilianvoss/musicsync,master,maven,,java8,,,,
+,maximilianvoss/musicsync,master,maven,,java11,,,,
 ,maximwebb/ellas-vs-maxims,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,maxistar/TextPad,master,,,java8,,,,
 ,maxlaverse/kubernetes-cli-plugin,master,maven,,java8,,,,
@@ -27408,7 +27408,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mibo/mi-utils-dependabot,master,maven,,java8,,,,
 ,michael-rapp/AndroidMaterialDialog,master,,,java8,,,,
 ,michael-rapp/ChromeLikeTabSwitcher,master,,,java8,,,,
-,michael-simons/biking2,public,maven,,java11,,,,
+,michael-simons/biking2,public,maven,,java17,,,,
 ,michael-simons/wro4j-spring-boot-starter,master,maven,,java8,,,,
 ,michaelboyd/comic-book,master,maven,,java8,,,,
 ,michaelisvy/hibernate-4-spring-3.1-samples,master,maven,,java8,,,,
@@ -27417,7 +27417,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,michaelklishin/quartz-mongodb,master,,,java8,,,,
 ,michaellavelle/spring-data-dynamodb,master,maven,,java8,,,,
 ,michaelliao/compiler,master,maven,,java8,,,,
-,michaelliao/itranswarp,master,maven,,java8,,,,
+,michaelliao/itranswarp,master,maven,,java17,,,,
 ,michaelliao/jsonstream,master,maven,,java8,,,,
 ,michaelliao/shici,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,michaelneale/jenkins-lifx-notifier-plugin,master,maven,,java8,,,,
@@ -27460,7 +27460,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,microg/GmsCore,master,,,java8,,,,
 ,microg/UnifiedNlp,master,,,java8,,,,
 ,micromata/javaapiforkml,master,maven,,java8,,,,
-,micromata/projectforge,develop,maven,,java8,,,,
+,micromata/projectforge,develop,maven,,java11,,,,
 ,micrometer-metrics/micrometer,main,,,java8,,,,
 ,micronaut-guides/micronaut-azure-function,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,micronaut-projects/micronaut-acme,master,,,java8,,,,
@@ -27595,7 +27595,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,microsoft/java-webapp-oidc-migrate-poc,master,maven,,java8,,,,
 ,microsoft/jfr-streaming,main,maven,,java8,,,,
 ,microsoft/kafka-connect-cosmosdb,dev,maven,,java11,,,,
-,microsoft/lsif-java,main,maven,,java11,,,,
+,microsoft/lsif-java,main,maven,,java17,,,,
 ,microsoft/mariadb-connector-j,master,maven,,java8,,,,
 ,microsoft/masc,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,microsoft/movie-db-java-on-azure,master,maven,,java8,,,,
@@ -27722,7 +27722,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,milanxiaotiejiang/diycode,master,,,java8,,,,
 ,miliare/test-jhipster,master,maven,,java8,,,,
 ,milindsatpute/newthis,master,maven,,java8,,,,
-,milis92/Krang,main,,,java8,,,,
+,milis92/Krang,main,,,java11,,,,
 ,milo-minderbinder/repository-mirrors-gradle-plugin,master,,,java8,,,,
 ,miltonbo/adminfaces-spring-boot,master,maven,,java8,,,,
 ,miltonio/milton2,master,maven,,java8,,,,
@@ -27779,7 +27779,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mirage22/spring-boot-freemaker-demo,master,,gradle,java8,,,,
 ,miraj12/CS499.JHipster,master,maven,,java8,,,,
 ,miraz77/jhipster-sample-application,master,maven,,java8,,,,
-,mircheqtm/VATRate,main,maven,,java8,,,,
+,mircheqtm/VATRate,main,maven,,java11,,,,
 ,mirchiseth/jhHelloWorld,master,maven,,java8,,,,
 ,mirchiseth/jhipsterSampleApplication,master,maven,,java8,,,,
 ,mirchiseth/jhtek,master,maven,,java8,,,,
@@ -27790,7 +27790,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mirrajabi/okhttp-json-mock,master,,,java8,,,,
 ,mirrajabi/search-dialog,master,,,java8,,,,
 ,mirromutth/r2dbc-mysql,main,maven,,java8,,,,
-,misakuo/svgtoandroid,master,,,java8,,,,
+,misakuo/svgtoandroid,master,,,java8,,,TRUE,Gradle wrapper 4.9 is not supported
 ,miscar/gradle-utilities,main,,,java8,,,,
 ,misdake/immutable_geometry_lib,2,maven,,java8,,,,
 ,miserydx/FakeBiliBili,master,,,java8,,,,
@@ -27806,7 +27806,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,misty2020/spring-framework,master,,gradle,java8,,,,
 ,mitVCU/HealthHacks2017,master,,,java8,,,,
 ,mitVCU/Swifey,master,,,java8,,,,
-,mitallast/netty-queue,master,maven,,java8,,,,
+,mitallast/netty-queue,master,maven,,java11,,,,
 ,mitallast/simple-java-profiler,master,maven,,java8,,,,
 ,mitch-lbw/javassist,master,maven,,java8,,,,
 ,mitch990/code,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -27880,7 +27880,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mkremins/fanciful,master,maven,,java8,,,,
 ,mkrishna23/jhipsterSampleApplication,master,maven,,java8,,,,
 ,mkristiansen/gradle-plantuml-mk-plugin,master,,,java8,,,TRUE,Build uses Gradle 3.x
-,mkrupal09/EasyAdapter,master,,,java8,,,,
+,mkrupal09/EasyAdapter,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,mkrystian/lvote-server,master,maven,,java8,,,,
 ,mksgrd/MobileButler,master,,,java8,,,,
 ,mktmpio/mktmpio-jenkins-plugin,master,maven,,java8,,,,
@@ -27919,7 +27919,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mmdemirbas/timeline,master,maven,,java8,,,,
 ,mmesnjak/pet-store-4-rbc,master,maven,,java8,,,,
 ,mmin18/FlexLayout,master,,gradle,java8,,,,
-,mmin18/RealtimeBlurView,master,,,java8,,,,
+,mmin18/RealtimeBlurView,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,mmjang/ankihelper,master,,,java8,,,,
 ,mmkdissa/Sugah,master,maven,,java8,,,,
 ,mmoamenn/LuckyWheel_Android,master,,,java8,,,,
@@ -27941,12 +27941,12 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mnemonic-no/common-services,master,maven,,java8,,,,
 ,mnemonic-no/commons,master,maven,,java8,,,,
 ,mneri/csv,master,,,java8,,,,
-,mneri/lambda,master,,,java8,,,,
+,mneri/lambda,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,mneri/offer-service,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,mngsk/device-detector,master,maven,,java8,,,,
 ,mnhlt/TMP-JOSM,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,mnky4a6/powermock,master,maven,,java8,,,,
-,mnlipp/jdrupes-httpcodec,master,,,java8,,,,
+,mnlipp/jdrupes-httpcodec,master,,,java11,,,,
 ,mnlipp/jdrupes-mdoclet,master,,,java11,,,,
 ,mnogueron/swedish-guys,master,maven,,java8,,,,
 ,mnunezdm/PopularMovies,master,,gradle,java8,,,,
@@ -27967,7 +27967,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mocanjie/mymvc-spring-boot-starter,master,maven,,java8,,,,
 ,mochat-cloud/mochat-java,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,mock-server/mockserver,master,maven,,java8,,,,
-,mockito/mockito,main,,,java8,,,,
+,mockito/mockito,main,,,java11,,,,
 ,mockito/shipkit-example,master,,,java8,,,,
 ,mocleiri/github-oauth-plugin,master,maven,,java8,,,,
 ,modakanalytics/botworks,master,maven,,java8,,,,
@@ -28034,7 +28034,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mohitum007/OpenWeatherDemo,master,,,java8,,,,
 ,mohsal110/final_mahem2,master,,,java8,,,,
 ,mohsennoghli/jh-sampel,master,maven,,java8,,,,
-,mohsenoid/marvel,master,,,java8,,,,
+,mohsenoid/marvel,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,mohsin-moideen/Cars-on-rent,master,maven,,java8,,,,
 ,mojavelinux/forge-plugin-arquillian-extensions,master,maven,,java8,,,,
 ,mojo-executor/mojo-executor,main,maven,,java8,,,,
@@ -28071,7 +28071,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,moko256/twitlatte,master,,,java8,,,,
 ,mokshamanukantha/jhipster-sample-application,master,maven,,java8,,,,
 ,moleksyuk/vcs-semantic-version,master,,,java8,,,TRUE,Build uses Gradle 2.x
-,molgenis/systemsgenetics,master,maven,,java8,,,,
+,molgenis/systemsgenetics,master,maven,,java11,,,,
 ,molinam/testeEdu,master,maven,,java8,,,,
 ,molindo/esi4j,master,maven,,java8,,,,
 ,mollyim/mollyim-android,main,,,java8,,,,
@@ -28291,7 +28291,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,msayan/tutorial-view,master,,,java8,,,,
 ,mscharhag/oleaster,master,maven,,java8,,,,
 ,msdc/dispatch,master,maven,,java8,,,,
-,msdousti/OWASP-Java,master,maven,,java8,,,,
+,msdousti/OWASP-Java,master,maven,,java11,,,,
 ,msdx/IconTabPageIndicator,master,,,java8,,,,
 ,msenthilkumarsam/JHipsterSample,master,maven,,java8,,,,
 ,msenthilkumarsam/SampleCodeGen,master,maven,,java8,,,,
@@ -28447,7 +28447,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mutisyap/Meliora101,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,mutisyap/amini-v2,master,maven,,java8,,,,
 ,mutouji/testredis,master,,,java8,,,,
-,mutualmobile/Barricade,master,,,java8,,,,
+,mutualmobile/Barricade,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,mutualmobile/CardStackUI,master,,,java8,,,,
 ,muxiangqiu/bdf3,master,maven,,java8,,,,
 ,muyinchen/migo-security,master,maven,,java8,,,,
@@ -28492,16 +28492,16 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mybatis/ehcache-cache,master,maven,,java8,,,,
 ,mybatis/freemarker-scripting,master,maven,,java8,,,,
 ,mybatis/generator,master,,,java8,,,TRUE,Top-level build tool file is missing
-,mybatis/guice,master,maven,,java8,,,,
-,mybatis/hazelcast-cache,master,maven,,java8,,,,
-,mybatis/ibatis-2,master,maven,,java8,,,,
-,mybatis/jpetstore-6,master,maven,,java8,,,,
+,mybatis/guice,master,maven,,java11,,,,
+,mybatis/hazelcast-cache,master,maven,,java11,,,,
+,mybatis/ibatis-2,master,maven,,java11,,,,
+,mybatis/jpetstore-6,master,maven,,java11,,,,
 ,mybatis/memcached-cache,master,maven,,java8,,,,
-,mybatis/migrations,master,maven,,java8,,,,
+,mybatis/migrations,master,maven,,java11,,,,
 ,mybatis/mybatis-3,master,,,java8,,,,
 ,mybatis/mybatis-dynamic-sql,master,maven,,java8,,,,
 ,mybatis/oscache-cache,master,maven,,java8,,,,
-,mybatis/redis-cache,master,maven,,java8,,,,
+,mybatis/redis-cache,master,maven,,java11,,,,
 ,mybatis/spring,master,,,java8,,,,
 ,mybatis/spring-boot-starter,master,,,java8,,,,
 ,mycelium-com/wallet-android,master,,,java8,,,,
@@ -28534,7 +28534,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,mythz/java-linq-examples,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,myui/hivemall,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,myungchoi/GT-FHIR2,master,maven,,java8,,,,
-,myxzjie/cms,master,maven,,java8,,,,
+,myxzjie/cms,master,maven,,java11,,,,
 ,myzenon/SE331-lab11,master,,,java8,,,,
 ,myzone/pest-control-enterprise,develop,maven,,java8,,,,
 ,mzabriskie/PocketNode,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -28658,7 +28658,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,nateyolles/aem-metrics-demo,master,maven,,java8,,,,
 ,nateyolles/aem-osgi-annotation-demo,master,maven,,java8,,,,
 ,nateyolles/aem-slash-conf,master,maven,,java8,,,,
-,nathanbowman/mvnVersion,master,maven,,java8,,,,
+,nathanbowman/mvnVersion,master,maven,,java11,,,,
 ,nativefairie/jhipsterSampleApplication,master,maven,,java8,,,,
 ,nativelibs4java/BridJ,master,maven,,java8,,,,
 ,nativelibs4java/JNAerator,master,maven,,java8,,,,
@@ -28699,8 +28699,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,naver/universal-analytics-java,master,maven,,java8,,,,
 ,navhits/EOC-test-android,master,,,java8,,,,
 ,navi-guy/ufisi,master,,,java8,,,TRUE,Top-level build tool file is missing
-,navi25/Nachos,master,,,java8,,,,
-,navi25/SunRise,master,,,java8,,,,
+,navi25/Nachos,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
+,navi25/SunRise,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,navigosgroupjsc/topitworks-hackathon-java,master,maven,,java8,,,,
 ,navikt/stelvio,master,maven,,java8,,,,
 ,navintkr/java-copyblob-func-app,master,maven,,java8,,,,
@@ -28734,8 +28734,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,nccgroup/BurpSuiteHTTPSmuggler,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,nccgroup/Decoder-Improved,master,,,java8,,,,
 ,nccgroup/HTTPSignatures,main,maven,,java8,,,,
-,nccgroup/LoggerPlusPlus,master,,,java8,,,,
-,nccgroup/freddy,master,,gradle,java8,,,,
+,nccgroup/LoggerPlusPlus,master,,,java17,,,,
+,nccgroup/freddy,master,,gradle,java11,,,,
 ,nccgroup/log4j-jndi-be-gone,main,,,java8,,,,
 ,nccgroup/pcap-burp,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,nccgroup/scenester,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -28744,7 +28744,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ncnegoleo/pizzaria-daca-web,master,maven,,java8,,,,
 ,ncolomer/elasticsearch-osmosis-plugin,2.1.x,maven,,java8,,,,
 ,ncscamacho/prueba,master,maven,,java8,,,,
-,ndew623/AndroidCrypt,master,,,java8,,,,
+,ndew623/AndroidCrypt,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,ndjordjevic/medical-rec,master,maven,,java8,,,,
 ,ndroi/easy163,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,ndrwdn/mountebank-gradle,main,,,java8,,,TRUE,Build uses Gradle 2.x
@@ -28839,10 +28839,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,neo4j-contrib/neo4j-tinkerpop-api-impl,3.2,maven,,java8,,,,
 ,neo4j-contrib/rabbithole,3.5,maven,,java8,,,,
 ,neo4j-contrib/spatial,master,maven,,java8,,,,
-,neo4j-labs/neosemantics,4.4,maven,,java8,,,,
+,neo4j-labs/neosemantics,4.4,maven,,java11,,,,
 ,neo4j/clirr-maven-plugin,master,maven,,java8,,,,
 ,neo4j/cypher-shell,4.3,,,java8,,,,
-,neo4j/docker-neo4j,master,maven,,java8,,,,
+,neo4j/docker-neo4j,master,maven,,java17,,,,
 ,neo4j/docs-maven-plugin,master,maven,,java8,,,,
 ,neo4j/doctools,master,maven,,java8,,,,
 ,neo4j/driver-documentation,dev,,,java8,,,TRUE,Build uses Gradle 3.x
@@ -28878,7 +28878,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,netbeneficios/jhipster-sample-application,master,maven,,java8,,,,
 ,netfalo/gradle-raml-plugin,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,netflix/spectator,main,,,java8,,,,
-,netherfoam/MaxBans-Plus,master,maven,,java8,,,,
+,netherfoam/MaxBans-Plus,master,maven,,java11,,,,
 ,netifi/gradle-flatbuffers-plugin,master,,,java8,,,,
 ,netmackan/ATimeTracker,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,netmelody/ci-eye,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -28897,9 +28897,9 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,netty/netty-incubator-transport-io_uring,main,maven,,java8,,,,
 ,netty/netty-jni-util,main,maven,,java8,,,,
 ,networknt/json-schema-validator,master,maven,,java8,,,,
-,networknt/light-4j,master,maven,,java8,,,,
-,networknt/light-oauth2,master,maven,,java8,,,,
-,networknt/light-rest-4j,master,maven,,java8,,,,
+,networknt/light-4j,master,maven,,java11,,,,
+,networknt/light-oauth2,master,maven,,java11,,,,
+,networknt/light-rest-4j,master,maven,,java11,,,,
 ,networkupstools/jNut,master,maven,,java8,,,,
 ,netxms/netxms,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,netzwerg/gradle-release-plugin,master,,,java8,,,TRUE,Build uses Gradle 2.x
@@ -28958,8 +28958,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,nextbreakpoint/flink-client,master,maven,,java8,,,,
 ,nextcloud/Android-SingleSignOn,master,,,java8,,,,
 ,nextcloud/android-library,master,,,java8,,,,
-,nextcloud/news-android,master,,,java8,,,,
-,nextdoor/bender,master,maven,,java8,,,,
+,nextcloud/news-android,master,,,java11,,,,
+,nextdoor/bender,master,maven,,java11,,,,
 ,nextflow-io/nextflow,master,,,java8,,,,
 ,neyao-advanced-java/JavaAdvancedUsage,master,maven,,java8,,,,
 ,neykov/extract-tls-secrets,master,maven,,java8,,,,
@@ -28982,7 +28982,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ngageoint/simple-features-java,master,maven,,java8,,,,
 ,ngageoint/simple-features-proj-java,master,maven,,java8,,,,
 ,ngageoint/simple-features-wkb-java,master,maven,,java8,,,,
-,ngageoint/tiff-java,master,maven,,java8,,,,
+,ngageoint/tiff-java,master,maven,,java11,,,,
 ,ngallagher/simplexml,master,maven,,java8,,,,
 ,ngammoudi/jhipsterSampleApplication,master,maven,,java8,,,,
 ,ngbdf/redis-manager,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -29017,7 +29017,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,nhuray/dropwizard-spring,master,maven,,java8,,,,
 ,nhuttrung/gae-spring,master,,gradle,java8,,,,
 ,nibabadeyeye/microservice,master,,,java8,,,TRUE,Top-level build tool file is missing
-,nibbydev/poewatch,master,maven,,java8,,,,
+,nibbydev/poewatch,master,maven,,java11,,,,
 ,nic-delhi/AarogyaSetu_Android,master,,,java8,,,,
 ,nicholashauschild/gradle-dependency-info-plugin,master,,,java8,,,,
 ,nichunen/HbaseDemo,master,maven,,java8,,,,
@@ -29039,8 +29039,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,nickiatro/k9-mail-390,master,,,java8,,,,
 ,nickman/netty-ajax-server,master,maven,,java8,,,,
 ,nickrfer/hub-shifts,master,maven,,java8,,,,
-,nickrobison/tdtree,master,,,java8,,,,
-,nickrobison/trestle,master,,,java8,,,,
+,nickrobison/tdtree,master,,,java11,,,,
+,nickrobison/trestle,master,,,java11,,,,
 ,nickrussler/Android-Wifi-Hotspot-Manager-Class,master,,,java8,,,,
 ,nickrussler/email-to-pdf-converter,master,,,java8,,,,
 ,nicksellen/reka,master,maven,,java8,,,,
@@ -29069,7 +29069,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,nidi3/raml-tester,master,maven,,java8,,,,
 ,nidi3/raml-tester-proxy,master,maven,,java8,,,,
 ,niefy/wx-api,master,maven,,java8,,,,
-,nielsbasjes/logparser,master,maven,,java8,,,,
+,nielsbasjes/logparser,master,maven,,java11,,,,
 ,nielsutrecht/jwt-angular-spring,master,maven,,java8,,,,
 ,niemals-stop/gradle-dcr-plugin,main,,,java8,,,,
 ,niezhiliang/springboot-rabbitmq,master,maven,,java8,,,,
@@ -29138,8 +29138,8 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ninjaframework/ninja,develop,maven,,java8,,,,
 ,ninjaframework/ninja-ebean,master,maven,,java8,,,,
 ,ninthDevilHAUNSTER/codeql_test_project,master,,gradle,java8,,,,
-,niorgai/StatusBarCompat,master,,,java8,,,,
-,niqdev/ipcam-view,master,,,java8,,,,
+,niorgai/StatusBarCompat,master,,,java8,,,TRUE,Gradle wrapper 4.7 is not supported
+,niqdev/ipcam-view,master,,,java11,,,,
 ,nirash123/ESchoolSL_edit,main,,,java8,,,,
 ,nirbar/jenkins-ibvc-plugin,master,maven,,java8,,,,
 ,nirhart/ParallaxScroll,master,,,java8,,,,
@@ -29164,7 +29164,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,nisrineRH/testSuivi,master,maven,,java8,,,,
 ,nisrineRH/testo,master,maven,,java8,,,,
 ,nisrulz/Sensey,master,,,java8,,,,
-,nisrulz/packagehunter,master,,,java8,,,,
+,nisrulz/packagehunter,master,,,java8,,,TRUE,Gradle wrapper 4.3.1 is not supported
 ,nisrulz/qreader,master,,,java8,,,,
 ,nisrulz/screenshott,master,,,java8,,,,
 ,nisrulz/sensey,master,,,java8,,,,
@@ -29198,7 +29198,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,niuzhiweimr/askwalking,master,maven,,java8,,,,
 ,nivance/image-similarity,master,maven,,java8,,,,
 ,nive02/Choremates,master,,,java8,,,,
-,nixiangge/gy-cloud,master,maven,,java8,,,,
+,nixiangge/gy-cloud,master,maven,,java17,,,,
 ,nixiton/dev-douanes_debug,master,maven,,java8,,,,
 ,nixuechao/security-jwt,master,maven,,java8,,,,
 ,niyaou/ledong-tennis,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -29222,7 +29222,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,nla/dl-models,master,maven,,java8,,,,
 ,nla/heritrixctl,master,maven,,java8,,,,
 ,nla/httrack2warc,master,maven,,java8,,,,
-,nla/jwebrenderer,master,maven,,java8,,,,
+,nla/jwebrenderer,master,maven,,java11,,,,
 ,nla/oclc-dbutils,master,maven,,java8,,,,
 ,nla/outbackcdx,master,maven,,java8,,,,
 ,nla/outbackproxy,master,maven,,java8,,,,
@@ -29248,7 +29248,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,noahluftyang/design-of-data-structure-assignment-2nd,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,noamda/DPaaSAuth,master,maven,,java8,,,,
 ,noamt/rest-gradle-plugin,master,,,java8,,,TRUE,Build uses Gradle 2.x
-,noboomu/proteus,master,maven,,java8,,,,
+,noboomu/proteus,master,maven,,java11,,,,
 ,nobuoka/vc-gradle-android-sdk-manager,dev,,,java8,,,TRUE,Build uses Gradle 2.x
 ,noctarius/tengi,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,nocturnalbeast/KPApp,master,,,java8,,,,
@@ -29300,7 +29300,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,notHide/MyHoveringScroll,master,,,java8,,,,
 ,nothingax/micro-DB,main,maven,,java8,,,,
 ,nothub/AntiSpeed,master,maven,,java8,,,,
-,nothub/AoC2020,master,maven,,java8,,,,
+,nothub/AoC2020,master,maven,,java11,,,,
 ,nothub/JavaVersion,master,maven,,java8,,,,
 ,nothub/Log4jInjectionFilter,master,maven,,java8,,,,
 ,nothub/PacketDump,master,,,java8,,,,
@@ -29325,7 +29325,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,novoda/download-manager,release,,,java8,,,,
 ,novoda/gradle-build-properties-plugin,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,novoda/gradle-static-analysis-plugin,master,,,java8,,,,
-,novoda/notils,master,,,java8,,,,
+,novoda/notils,master,,,java8,,,TRUE,Gradle wrapper 4.4.1 is not supported
 ,novoda/rxpresso,master,,,java8,,,,
 ,novoda/spritz,master,,,java8,,,,
 ,novoda/sqlite-analyzer,master,,,java8,,,TRUE,Build uses Gradle 2.x
@@ -29350,7 +29350,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,nrl-gradle/projects-plugin,release,,,java8,,,,
 ,nrl-gradle/pub-plugin,release,,,java8,,,,
 ,nrl-gradle/util-plugin,release,,,java8,,,,
-,nroduit/Weasis,master,maven,,java8,,,,
+,nroduit/Weasis,master,maven,,java11,,,,
 ,nrohmen/Clean-Android-Code,master,,,java8,,,,
 ,nsclass/ns-svg-converter,master,,,java8,,,,
 ,nshmura/RecyclerTabLayout,master,,,java8,,,,
@@ -29396,7 +29396,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,nuptboyzhb/SuperSwipeRefreshLayout,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,nurkiewicz/LazySeq,master,maven,,java8,,,,
 ,nurkiewicz/async-retry,master,maven,,java8,,,,
-,nurkiewicz/elastic-flux,master,,,java8,,,,
+,nurkiewicz/elastic-flux,master,,,java8,,,TRUE,Gradle wrapper 4.3.1 is not supported
 ,nurkiewicz/rxjava-book-examples,master,,,java8,,,,
 ,nurkiewicz/spring-data-jdbc-repository,master,maven,,java8,,,,
 ,nurkiewicz/typeof,master,maven,,java8,,,,
@@ -29404,7 +29404,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,nury-garryyev/AltoroJ,main,,,java8,,,,
 ,nury-garryyev/easybuggy,main,maven,,java8,,,,
 ,nus-ncl/services-in-one,master,,,java8,,,,
-,nusco/narjillos,master,,gradle,java8,,,,
+,nusco/narjillos,master,,gradle,java11,,,,
 ,nusratjahannira/BusTicket,master,,,java8,,,,
 ,nuttachaiNew/BtxWebApp,master,maven,,java8,,,,
 ,nuttycom/commons-pipeline,master,maven,,java8,,,,
@@ -29431,7 +29431,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,nwillc/buildInfo,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,nwpushuai/BUCK,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,nwy140/AndroidStudioProjectsJava,master,,,java8,,,TRUE,Top-level build tool file is missing
-,nxzh/java-multithreading,master,maven,,java8,,,,
+,nxzh/java-multithreading,master,maven,,java11,,,,
 ,nyaang/CourseDesigns,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,nyaguthii/silva,master,maven,,java8,,,,
 ,nyankosama/simple-netty-source,master,maven,,java8,,,,
@@ -29444,7 +29444,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,nytimes/Store,feature/rx2,,,java8,,,,
 ,nzakas/cssembed,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,nzakas/props2js,master,,,java8,,,TRUE,Top-level build tool file is missing
-,nzbget/android,master,,,java8,,,,
+,nzbget/android,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,nzoudy/JSON-Web-Token,master,maven,,java8,,,,
 ,o1c-dev/o1c,main,maven,,java8,,,,
 ,oahnus/luqian-common,master,maven,,java8,,,,
@@ -29461,7 +29461,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,obilan/jhipsterSampleApplication,master,maven,,java8,,,,
 ,objectbox/objectbox-java,main,,,java8,,,,
 ,objectify/objectify,master,maven,,java8,,,,
-,objectionary/eo,master,maven,,java8,,,,
+,objectionary/eo,master,maven,,java11,,,,
 ,objectivePinta/dumb,master,maven,,java8,,,,
 ,oblac/jodd,master,,,java8,,,,
 ,oblac/jodd-util,master,,,java8,,,,
@@ -29470,7 +29470,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,obsidiandynamics/fulcrum,master,,,java8,,,,
 ,obsidiandynamics/indigo,master,,,java8,,,,
 ,obsidiandynamics/jackdaw,master,,,java8,,,,
-,obsidiandynamics/kafdrop,master,maven,,java8,,,,
+,obsidiandynamics/kafdrop,master,maven,,java11,,,,
 ,obsidiandynamics/leecheswithvacuums,master,,,java8,,,,
 ,obsidiandynamics/log4j-extras,master,,,java8,,,,
 ,obsidiandynamics/meteor,master,,,java8,,,,
@@ -29608,7 +29608,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ololx/plain-old-retro-shooter,main,maven,,java8,,,,
 ,ololx/simple-binary-system,main,maven,,java8,,,,
 ,ololx/simple-gis,main,maven,,java8,,,,
-,ololx/simple-plc,develop,maven,,java8,,,,
+,ololx/simple-plc,develop,maven,,java11,,,,
 ,ololx/simple-task-board,main,,,java8,,,,
 ,ololx/spring-boot-custom-message-converting-instances,main,maven,,java8,,,,
 ,ololx/survey-service,master,maven,,java8,,,,
@@ -29744,7 +29744,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,openapi-tools/swagger-maven-plugin,master,maven,,java8,,,,
 ,openapi4j/openapi4j,master,,,java8,,,,
 ,openbakery/gradle-xcodePlugin,main,,,java8,,,,
-,openbaton/NFVO,master,,,java8,,,,
+,openbaton/NFVO,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,opencast/opencast,develop,maven,,java11,,,,
 ,opencollab/jlatexmath,master,maven,,java8,,,,
 ,openconnect/openconnect,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -29767,7 +29767,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,opengl-8080/sample-gradle-custom-plugin,master,,gradle,java8,,,,
 ,openhab/openhab,main,maven,,java8,,,,
 ,openhab/openhab-android,main,,,java8,,,,
-,openhab/openhab-core,main,maven,,java8,,,,
+,openhab/openhab-core,main,maven,,java11,,,,
 ,openhab/openhab2-addons,2.5.x,maven,,java8,,,,
 ,openid/OpenYOLO-Android,master,,,java8,,,,
 ,openimaj/openimaj,master,maven,,java8,,,,
@@ -29896,7 +29896,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,openzipkin-contrib/brave-opentracing,master,maven,,java8,,,,
 ,openzipkin/brave,master,maven,,java8,,,,
 ,openzipkin/brave-karaf,master,maven,,java8,,,,
-,openzipkin/zipkin,master,maven,,java8,,,,
+,openzipkin/zipkin,master,maven,,java11,,,,
 ,openzipkin/zipkin-aws,master,maven,,java8,,,,
 ,openzipkin/zipkin-dependencies,master,maven,,java8,,,,
 ,openzipkin/zipkin-finagle,master,maven,,java8,,,,
@@ -29933,7 +29933,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,oracle/coherence-eclipse-plugin,main,maven,,java8,,,,
 ,oracle/coherence-helidon-sockshop-sample,master,maven,,java8,,,,
 ,oracle/coherence-idea-plugin,master,,,java8,,,,
-,oracle/coherence-kafka,master,maven,,java8,,,,
+,oracle/coherence-kafka,master,maven,,java11,,,,
 ,oracle/coherence-micronaut-sockshop-sample,master,maven,,java11,,,,
 ,oracle/coherence-oci,main,maven,,java8,,,,
 ,oracle/coherence-spring-sockshop-sample,master,maven,,java11,,,,
@@ -29967,7 +29967,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,oraxen/oraxen,master,,,java8,,,,
 ,oraxen/protectionlib,master,,,java8,,,,
 ,orayas1996/MyAppAae,master,,,java8,,,,
-,orbisgis/h2gis,master,maven,,java8,,,,
+,orbisgis/h2gis,master,maven,,java11,,,,
 ,orbit-mvi/orbit-swift-gradle-plugin,main,,,java8,,,,
 ,orbit/orbit,master,,,java8,,,,
 ,orbizzle99/jhip,master,maven,,java8,,,,
@@ -29986,7 +29986,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,org-codetribe/Spotlight-Server,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,org-eliasrdrgz/myhipster,master,maven,,java8,,,,
 ,organicveggie/metrics-statsd,master,maven,,java8,,,,
-,orgzly/org-java,master,,,java8,,,,
+,orgzly/org-java,master,,,java11,,,,
 ,orhanobut/bee,master,,,java8,,,,
 ,orhanobut/dialogplus,master,,,java8,,,,
 ,orhanobut/hawk,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
@@ -30093,7 +30093,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,overmighty/croissant-example,master,,,java8,,,,
 ,overpassion/egovframe-msa-reserve-check-service,main,,,java8,,,,
 ,overpassion/egovframe-msa-reserve-item-service,main,,,java8,,,,
-,oversecio/oversec,master,,,java8,,,,
+,oversecio/oversec,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,oversecured/ovaa,master,,,java8,,,,
 ,oversecured/oversecured-android-gradle,master,,,java8,,,,
 ,overtakerx/function_multicloud_demo,master,,,java8,,,,
@@ -30148,9 +30148,9 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,p6spy/p6spy,master,,,java8,,,,
 ,pablo/raf,master,maven,,java8,,,,
 ,pablor21/jhipstertest,master,maven,,java8,,,,
-,pac4j/pac4j,master,maven,,java8,,,,
+,pac4j/pac4j,master,maven,,java11,,,,
 ,pac4j/play-pac4j,master,maven,,java8,,,,
-,pac4j/spark-pac4j,master,maven,,java8,,,,
+,pac4j/spark-pac4j,master,maven,,java11,,,,
 ,pac4j/spring-security-pac4j,master,maven,,java8,,,,
 ,pac4j/vertx-pac4j,master,maven,,java8,,,,
 ,pacampbell/Game,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -30176,7 +30176,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,paissad/soapui-multi-testrunner,develop,maven,,java8,,,,
 ,pakerfeldt/okhttp-signpost,master,maven,,java8,,,,
 ,pakkiraiah/GitJenkins,master,maven,,java8,,,,
-,palaima/DebugDrawer,master,,,java8,,,,
+,palaima/DebugDrawer,master,,,java8,,,TRUE,Gradle wrapper 4.2.1 is not supported
 ,palantir-baseline/gradle-launch-config-plugin,develop,,,java11,,,,
 ,palantir/Cinch,develop,,,java8,,,,
 ,palantir/Sysmon,master,maven,,java8,,,,
@@ -30351,7 +30351,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,patloew/NavigationViewFragmentAdapters,master,,,java8,,,,
 ,patloew/RxLocation,master,,,java8,,,,
 ,patloew/RxWear,1.x,,,java8,,,,
-,patloew/countries,kotlin,,,java8,,,,
+,patloew/countries,kotlin,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,patric-r/jvmtop,master,maven,,java8,,,,
 ,patrick-choe/mojang-spigot-remapper,main,,,java8,,,,
 ,patrick-doyle/dagger2-tutorial,master,,,java8,,,,
@@ -30404,11 +30404,11 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,pawelhaladyj/fmsJHipster,master,maven,,java8,,,,
 ,pawelkorus/fluent-generator,master,maven,,java8,,,,
 ,pawmot/dockerize-spring-boot,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
-,payara/Payara,master,maven,,java8,,,,
+,payara/Payara,master,maven,,java11,,,,
 ,payara/Payara-Examples,master,maven,,java8,,,,
 ,payatu/diva-android,master,,,java8,,,,
 ,payments-edu/payments-catalog,master,maven,,java8,,,,
-,paypal/Checkout-Java-SDK,develop,,,java8,,,,
+,paypal/Checkout-Java-SDK,develop,,,java8,,,TRUE,Gradle wrapper 4.8.1 is not supported
 ,paypal/Gibberish-Detector-Java,master,maven,,java8,,,,
 ,paypal/MrGerkins,master,maven,,java8,,,,
 ,paypal/PayPal-Java-SDK,master,,,java8,,,,
@@ -30443,7 +30443,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,pcan/feign-client-test,master,maven,,java8,,,,
 ,pcdavies/TwitterFeed,master,maven,,java8,,,,
 ,pcdv/jflask,master,,,java8,,,,
-,pcdv/jocket,master,,,java8,,,,
+,pcdv/jocket,master,,,java8,,,TRUE,Gradle wrapper 4.2.1 is not supported
 ,pcevikogullari/AndroidShortcuts,master,,,java8,,,,
 ,pchab/AndroidRTC,android-studio,,,java8,,,,
 ,pchauhan/EdittextWithTag,master,,,java8,,,,
@@ -30453,7 +30453,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,pchmn/tp_sir_opower,master,maven,,java8,,,,
 ,pcieszynski/tablettop-2,master,maven,,java8,,,,
 ,pcingola/BigDataScript,master,,,java8,,,TRUE,Top-level build tool file is missing
-,pcingola/SnpEff,master,maven,,java8,,,,
+,pcingola/SnpEff,master,maven,,java11,,,,
 ,pcj/google-options,master,maven,,java8,,,,
 ,pcpatidar4488/RecyclerVIewToPDF,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,pdecat/facelets,master,maven,,java8,,,,
@@ -30555,7 +30555,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,permissions-dispatcher/PermissionsDispatcher,master,,,java8,,,,
 ,perrycate/groupme-utils,master,maven,,java8,,,,
 ,persian-calendar/persian-calendar,main,,,java8,,,,
-,personium/personium-core,develop,maven,,java11,,,,
+,personium/personium-core,develop,maven,,java17,,,,
 ,personium/personium-engine,develop,maven,,java8,,,,
 ,personnummer/java,master,,,java8,,,,
 ,perwendel/spark,master,,,java8,,,,
@@ -30612,14 +30612,14 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,phatblat/Clamp,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,phatblat/ShellExec,main,,,java8,,,,
 ,phatblat/SwiftPM-Plugin,master,,,java8,,,,
-,phax/as2-lib,master,maven,,java8,,,,
+,phax/as2-lib,master,maven,,java11,,,,
 ,phax/jcodemodel,master,maven,,java8,,,,
-,phax/meta,master,maven,,java8,,,,
+,phax/meta,master,maven,,java11,,,,
 ,phax/ph-commons,master,maven,,java8,,,,
-,phax/ph-css,master,maven,,java8,,,,
-,phax/ph-oton,master,maven,,java8,,,,
-,phax/ph-schedule,master,maven,,java8,,,,
-,phax/ph-web,master,maven,,java8,,,,
+,phax/ph-css,master,maven,,java11,,,,
+,phax/ph-oton,master,maven,,java11,,,,
+,phax/ph-schedule,master,maven,,java11,,,,
+,phax/ph-web,master,maven,,java11,,,,
 ,phax/phoss-smp,master,maven,,java8,,,,
 ,phcamposfreitas/portal,develop,maven,,java8,,,,
 ,phcbest/SobBlogSystem,master,maven,,java8,,,,
@@ -30631,11 +30631,11 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,philcali/aoc,master,maven,,java8,,,,
 ,philcali/aws-global-infrastructure,master,maven,,java8,,,,
 ,philcali/config-helper,master,maven,,java8,,,,
-,philcali/device-pool,main,maven,,java8,,,,
+,philcali/device-pool,main,maven,,java11,,,,
 ,philcali/everywhere-model,master,,gradle,java8,,,,
 ,philcali/find-api,master,maven,,java8,,,,
 ,philcali/http-helper,master,maven,,java8,,,,
-,philcali/pillbox,main,maven,,java8,,,,
+,philcali/pillbox,main,maven,,java11,,,,
 ,philcali/s3-maven.plugin,master,maven,,java8,,,,
 ,philcali/template-helper,master,maven,,java8,,,,
 ,philipphecht/react-native-doc-viewer,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -30683,7 +30683,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,pierrecastel/sports-club-assistant,master,maven,,java8,,,,
 ,pierrecastel/truck-planner,master,maven,,java8,,,,
 ,pietelite/nope,master,,,java8,,,,
-,pietermartin/sqlg,master,maven,,java8,,,,
+,pietermartin/sqlg,master,maven,,java17,,,,
 ,pietras-jacek/ZadanieRekrutacyjne,master,maven,,java8,,,,
 ,pig-mesh/excel-spring-boot-starter,master,maven,,java8,,,,
 ,pig-mesh/pig,master,maven,,java8,,,,
@@ -30694,7 +30694,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,pili-engineering/pili-sdk-java,master,,,java8,,,,
 ,pilosoposerio/enlistment-enterprise,master,maven,,java8,,,,
 ,pilot007/jhipster-sample-application,master,maven,,java8,,,,
-,pinae/ctSESAM-android,master,,,java8,,,,
+,pinae/ctSESAM-android,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,pinball83/Masked-Edittext,public,,,java8,,,,
 ,pingcap/benchmarksql,5.0-mysql-support-opt-2.1,,,java8,,,TRUE,Top-level build tool file is missing
 ,pingfangushi/screw,master,maven,,java8,,,,
@@ -30724,7 +30724,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,pipimi110/pb-cms-codeql1,master,maven,,java8,,,,
 ,pipimi110/pb-cms-master,master,maven,,java8,,,,
 ,pipiobjo/gantt-gradle-task-plugin,master,,,java8,,,,
-,pippo-java/pippo,master,maven,,java8,,,,
+,pippo-java/pippo,master,maven,,java11,,,,
 ,piranhacloud/piranha,current,maven,,java11,,,,
 ,pircbotx/pircbotx,master,maven,,java8,,,,
 ,pirenato/Book-library,main,maven,,java8,,,,
@@ -30757,7 +30757,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,pkcool/samplejh,master,maven,,java8,,,,
 ,pkdevbox/commons-discovery,trunk,maven,,java8,,,,
 ,pkendzo/jhipster-sample-application,master,maven,,java8,,,,
-,pkjc/tic-tac-toe,master,,,java8,,,,
+,pkjc/tic-tac-toe,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,pkjvit/Android-Multi-Theme-UI,master,,,java8,,,,
 ,pkmsoftpro/Breakout-Game,master,maven,,java8,,,,
 ,pkmsoftpro/GameMaker,master,maven,,java8,,,,
@@ -30775,7 +30775,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,plan-player-analytics/Plan,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,plannersistemas/selecao-estagiario-jsf,master,maven,,java8,,,,
 ,plantuml/plantuml,master,,,java8,,,,
-,plantuml/plantuml-server,master,maven,,java8,,,,
+,plantuml/plantuml-server,master,maven,,java11,,,,
 ,platanus/jasperserver,master,maven,,java8,,,,
 ,plateaukao/AutoScreenOnOff,master,,,java8,,,,
 ,platformlib/platformlib-gradle-wrapper-plugin,main,,,java8,,,,
@@ -30851,7 +30851,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,polo18/gestionStock,master,maven,,java8,,,,
 ,polopoly/rest4jmx,master,maven,,java8,,,,
 ,polyglot-compiler/polyglot,master,,,java8,,,TRUE,Top-level build tool file is missing
-,polyjdbc/polyjdbc,master,,,java8,,,,
+,polyjdbc/polyjdbc,master,,,java8,,,TRUE,Gradle wrapper 4.7 is not supported
 ,polyv/polyv-android-cloudClass-sdk-demo,master,,,java8,,,,
 ,pombreda/gpltool,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,pomes/gradle-plugin-distextra,master,,,java8,,,TRUE,Build uses Gradle 2.x
@@ -30883,7 +30883,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,potats0/shiroPoc,master,maven,,java8,,,,
 ,poudelsunil/covid-updates-api,main,maven,,java8,,,,
 ,poutsma/web-function-sample,master,maven,,java8,,,,
-,power4j/DictMapper,master,maven,,java8,,,,
+,power4j/DictMapper,master,maven,,java11,,,,
 ,power4j/EzCaptcha,master,maven,,java8,,,,
 ,power4j/esc-pos-printing,master,maven,,java8,,,,
 ,power4j/java-perf,master,maven,,java8,,,,
@@ -31085,13 +31085,13 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,prometheus/client_java,master,,,java8,,,,
 ,prometheus/cloudwatch_exporter,master,maven,,java8,,,,
 ,prometheus/jmx_exporter,master,,,java8,,,,
-,promregator/promregator,master,maven,,java8,,,,
+,promregator/promregator,master,maven,,java17,,,,
 ,proninyaroslav/libretorrent,master,,,java8,,,,
 ,prontera/spring-cloud-rest-tcc,master,maven,,java8,,,,
 ,prospero238/liquibase-runner,master,maven,,java8,,,,
 ,protegeproject/protege,master,maven,,java8,,,,
 ,protegeproject/protege-server,master,maven,,java8,,,,
-,protegeproject/swrlapi,master,maven,,java8,,,,
+,protegeproject/swrlapi,master,maven,,java11,,,,
 ,protegeproject/swrltab-plugin,master,maven,,java8,,,,
 ,protegeproject/webprotege,master,maven,,java8,,,,
 ,protop-io/protop-gradle-plugin,master,,,java8,,,,
@@ -31100,7 +31100,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,prout21/MCCM,master,maven,,java8,,,,
 ,prout21/MCCM-Automation,master,maven,,java8,,,,
 ,prout21/desktop,master,maven,,java8,,,,
-,provectus/kafka-ui,master,maven,,java8,,,,
+,provectus/kafka-ui,master,maven,,java11,,,,
 ,provenance-io/p8e-gradle-plugin,main,,,java8,,,,
 ,provenza24/jhipsterSampleApplication,master,maven,,java8,,,,
 ,prowebtiger/FindLancer,master,maven,,java8,,,,
@@ -31154,7 +31154,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,pulsarIO/realtime-analytics,master,maven,,java8,,,,
 ,pulse00/Symfony-2-Eclipse-Plugin,master,maven,,java8,,,,
 ,pulse00/Twig-Eclipse-Plugin,master,maven,,java8,,,,
-,pulsedev2/AppBuilder,main,maven,,java8,,,,
+,pulsedev2/AppBuilder,main,maven,,java17,,,,
 ,pulsepointinc/chronos-maven-plugin,master,maven,,java8,,,,
 ,puluceno/ca,master,maven,,java8,,,,
 ,pump-x/doubbo,master,maven,,java8,,,,
@@ -31229,7 +31229,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,pwntester/logging-log4j2,main,maven,,java8,,,,
 ,pwrliang/AsyncDatalog,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,pxb1988/dex2jar,2.x,,,java8,,,,
-,pxlsspace/Pxls,master,maven,,java8,,,,
+,pxlsspace/Pxls,master,maven,,java11,,,,
 ,py4j/py4j,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,pybeaudouin/pick-a-book,master,maven,,java8,,,,
 ,pydio/pydio-sdk-java,master,maven,,java8,,,,
@@ -31244,7 +31244,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,pysambrero/revenge_studio,master,maven,,java8,,,,
 ,pytorch/serve,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,pytorch/vision,main,,,java8,,,TRUE,Top-level build tool file is missing
-,pz-extender/pz-gradle,master,,,java8,,,,
+,pz-extender/pz-gradle,master,,,java11,,,,
 ,pzinsta/pizzeria,master,maven,,java8,,,,
 ,pzstorm/capsid,master,,,java8,,,,
 ,q13117/test-repo,master,maven,,java8,,,,
@@ -31254,7 +31254,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,q821863269/keep-learn,master,maven,,java8,,,,
 ,qa-guru/allure-notifications,master,,,java8,,,,
 ,qaedtguj123/smartVest,master,,,java8,,,,
-,qala-io/java-course,master,maven,,java8,,,,
+,qala-io/java-course,master,maven,,java17,,,,
 ,qanwi1970/dungeonmart,master,maven,,java8,,,,
 ,qapqap/TimelineView,master,,,java8,,,,
 ,qaqRose/concurrent,main,maven,,java8,,,,
@@ -31314,7 +31314,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,qiwen1997/springboot-multipartfile,master,maven,,java8,,,,
 ,qiwi-archive/java-money-utils,develop,,,java8,,,,
 ,qiwi/thrift-pool,master,maven,,java8,,,,
-,qizewei/AndroidMore,master,,,java8,,,,
+,qizewei/AndroidMore,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,qjoy/libGDX-Android-AppEffect,master,,,java8,,,,
 ,qld-gov-au/orders,master,maven,,java8,,,,
 ,qld-gov-au/seleniumHelper,master,maven,,java8,,,,
@@ -31344,7 +31344,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,qos-ch/logback,master,maven,,java8,,,,
 ,qos-ch/logback-contrib,master,maven,,java8,,,,
 ,qos-ch/reload4j,master,maven,,java8,,,,
-,qos-ch/slf4j,master,maven,,java8,,,,
+,qos-ch/slf4j,master,maven,,java11,,,,
 ,qq1026290752/app-management,master,maven,,java8,,,,
 ,qq1131603397/basedecode,master,maven,,java8,,,,
 ,qq1588518/JRediClients,master,maven,,java8,,,,
@@ -31406,7 +31406,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,quarkusio/quarkus-devtools-compat,main,maven,,java17,,,,
 ,quarkusio/quarkus-fs-util,main,maven,,java11,,,,
 ,quarkusio/quarkus-github-bot,main,,,java11,,,,
-,quarkusio/quarkus-http,main,maven,,java8,,,,
+,quarkusio/quarkus-http,main,maven,,java11,,,,
 ,quarkusio/quarkus-keycloak-adapter,master,maven,,java8,,,,
 ,quarkusio/quarkus-platform,main,maven,,java11,,,,
 ,quarkusio/quarkus-platform-bom-generator,main,maven,,java11,,,,
@@ -31529,7 +31529,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,raffccc/ejb,master,maven,,java8,,,,
 ,rafoli/splitest,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,ragavendirann/jhipsterSampleApplication,master,maven,,java8,,,,
-,ragdroid/rxify,master,,,java8,,,,
+,ragdroid/rxify,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,raghavpatnecha/smartmirror,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,ragill/nar-gradle-plugin,master,,,java8,,,,
 ,ragnarokkrr/rgn-doodling-azure,main,,,java8,,,TRUE,Top-level build tool file is missing
@@ -31716,7 +31716,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,raydac/mvn-golang,master,maven,,java8,,,,
 ,raydac/mvn-jlink,master,maven,,java8,,,,
 ,raydac/netbeans-mmd-plugin,master,,,java8,,,TRUE,Top-level build tool file is missing
-,raydac/zxpoly,master,maven,,java8,,,,
+,raydac/zxpoly,master,maven,,java11,,,,
 ,rayjcwu/dummy-es-auth-plugin,master,maven,,java8,,,,
 ,raylawjr/flickz,master,,,java8,,,,
 ,raylax/commons,master,maven,,java8,,,,
@@ -31750,9 +31750,9 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,rbkmoney/custom-actuator-endpoints,master,maven,,java8,,,,
 ,rbkmoney/custom-metrics-spring-boot-starter,master,maven,,java8,,,,
 ,rbkmoney/db-common-lib,master,maven,,java8,,,,
-,rbkmoney/fraudbusters,master,maven,,java8,,,,
+,rbkmoney/fraudbusters,master,maven,,java17,,,,
 ,rbkmoney/fraudo,master,maven,,java8,,,,
-,rbkmoney/geck,master,maven,,java8,,,,
+,rbkmoney/geck,master,maven,,java17,,,,
 ,rbkmoney/kafka-common-lib,master,maven,,java8,,,,
 ,rbkmoney/proxy-mocket-inspector,master,maven,,java8,,,,
 ,rbkmoney/proxy-mocketbank,master,maven,,java8,,,,
@@ -31777,7 +31777,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,rcgonzalezf/weather-app-demo,main,,,java8,,,,
 ,rchatley/SimpleWebApp,master,maven,,java8,,,,
 ,rchodava/datamill,master,maven,,java8,,,,
-,rchukh/trino-querylog,master,maven,,java8,,,,
+,rchukh/trino-querylog,master,maven,,java11,,,,
 ,rcongiu/Hive-JSON-Serde,develop,maven,,java8,,,,
 ,rcorvalao/agenda-contatos,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,rcpoison/jgrapht,master,maven,,java8,,,,
@@ -31794,7 +31794,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,rdelbru/SIREn,master,maven,,java8,,,,
 ,rdeman/jhtest,master,maven,,java8,,,,
 ,rdfhdt/hdt-java,master,maven,,java11,,,,
-,rdgoite/hca-monorepo,master,,,java8,,,,
+,rdgoite/hca-monorepo,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,rdhanasekarandev/exci-api,master,maven,,java8,,,,
 ,rdriessen/GameOfLife,Development,maven,,java8,,,,
 ,rdspring1/LSH_DeepLearning,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -31877,7 +31877,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,redis/jedis,master,maven,,java8,,,,
 ,redis/redis-om-spring,main,maven,,java8,,,,
 ,redisson/redisson,master,maven,,java8,,,,
-,redkale/redkale,master,maven,,java8,,,,
+,redkale/redkale,master,maven,,java11,,,,
 ,redlean/smartNewsletter,master,maven,,java8,,,,
 ,redline-smalltalk/redline-smalltalk,master,maven,,java8,,,,
 ,redmaplei/jhipster-jdl-demo,master,maven,,java8,,,,
@@ -31915,13 +31915,13 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,reiniergs/polyfill-service,master,maven,,java8,,,,
 ,reisub/HttPizza,master,,,java8,,,,
 ,reivaxzoom/workedExample,master,maven,,java8,,,,
-,rejasupotaro/kvs-schema,master,,,java8,,,,
+,rejasupotaro/kvs-schema,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,rejwan052/e-assignment,master,maven,,java8,,,,
 ,rekavihari/jhipster-message-application,master,maven,,java8,,,,
 ,rekavihari/jhipster-pawside-application,master,maven,,java8,,,,
 ,rekavihari/jhipsterJoinMe,master,maven,,java8,,,,
 ,rekhaputtaswamy/AndroidApps,master,,,java8,,,TRUE,Top-level build tool file is missing
-,rekire/DeeplinkBuilder,main,,,java8,,,,
+,rekire/DeeplinkBuilder,main,,,java11,,,,
 ,relaxart/LeoPort,master,,,java8,,,,
 ,relaxng/jing-trang,master,,gradle,java8,,,,
 ,release-engineering/pom-manipulation-ext,main,maven,,java8,,,,
@@ -31965,7 +31965,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,renxuelong/ComponentDemo,master,,,java8,,,,
 ,renyaoxiang/gradle-frontend,master,,gradle,java8,,,,
 ,renyuneyun/Easer,master,,,java8,,,,
-,replydev/Quboscanner,main,maven,,java8,,,,
+,replydev/Quboscanner,main,maven,,java11,,,,
 ,repoName,branch,buildTool,buildTool,javaVersion,style,buildAction,skip,skipReason
 ,reportengine/report-engine,development,maven,,java8,,,,
 ,reportportal/agent-java-testNG,develop,,,java8,,,,
@@ -31995,7 +31995,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,restsql/restsql,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,restx/restx,master,maven,,java8,,,,
 ,resty-gwt/resty-gwt,master,maven,,java8,,,,
-,retel-io/ari-proxy,master,maven,,java8,,,,
+,retel-io/ari-proxy,master,maven,,java11,,,,
 ,retep36/examples,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,retrive123/jhipster-sample-application,master,maven,,java8,,,,
 ,retrive123/test1,master,maven,,java8,,,,
@@ -32003,7 +32003,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,retrooper/packetevents,master,,,java8,,,,
 ,retropiler/retropiler,master,,,java8,,,,
 ,retrostreams/android-retrostreams,master,maven,,java8,,,,
-,reugn/dev-tools,master,maven,,java8,,,,
+,reugn/dev-tools,master,maven,,java11,,,,
 ,reuhreuh/valorant-api-client,master,maven,,java8,,,,
 ,reusu/FFXIVChnTextPatch,master,,gradle,java8,,,,
 ,revapi/revapi,main,maven,,java8,,,,
@@ -32045,7 +32045,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,rharter/auto-value-moshi,main,,,java8,,,,
 ,rharter/auto-value-parcel,main,,,java8,,,,
 ,rhatlapa/jboss-eap-quickstarts,7.0.x-develop,maven,,java8,,,,
-,rherrmann/eclipse-extras,main,maven,,java8,,,,
+,rherrmann/eclipse-extras,main,maven,,java11,,,,
 ,rhill2689/run-for-brew,master,maven,,java8,,,,
 ,rhiodam/jhipster-sample-application,master,maven,,java8,,,,
 ,rholder/fluent-hc-4.1.x,master,maven,,java8,,,,
@@ -32089,7 +32089,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ricardopieper/gradle-example-plugin,master,,gradle,java8,,,,
 ,ricardorlg/aws-device-farm-tractor-gradle-plugin,master,,,java8,,,,
 ,ricfeatherstone/openshift-pipelines-example,master,,,java8,,,,
-,richardlui/form-api,master,maven,,java8,,,,
+,richardlui/form-api,master,maven,,java11,,,,
 ,richardradics/MVPAndroidBootstrap,master,,,java8,,,,
 ,richardstartin/multi-matcher,master,,,java8,,,,
 ,richardwilly98/elasticsearch-river-mongodb,master,maven,,java8,,,,
@@ -32197,7 +32197,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,rnorth/visible-assertions,master,maven,,java8,,,,
 ,rnowling/simple-jms-example,master,,gradle,java8,,,,
 ,roanrobersson/rshop-be,master,maven,,java8,,,,
-,roax47/FootballManager,master,maven,,java8,,,,
+,roax47/FootballManager,master,maven,,java11,,,,
 ,rob42/freeboard-server,master,maven,,java8,,,,
 ,robekson/jhipster-sample-application1,master,maven,,java8,,,,
 ,robekson/obra,master,maven,,java8,,,,
@@ -32231,13 +32231,13 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,robink/tap-ganalytics,master,maven,,java8,,,,
 ,robinlafleur/BeaverCoffee,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,robinrusli/jhipster-sample-application,master,maven,,java8,,,,
-,robinst/autolink-java,main,maven,,java8,,,,
+,robinst/autolink-java,main,maven,,java11,,,,
 ,robinst/git-merge-repos,master,maven,,java8,,,,
 ,robmelfi/21-points-react,master,maven,,java8,,,,
 ,robo-code/robocode,master,,,java8,,,,
 ,robocorp/robotframework-lsp,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,roboguice/roboguice,master,maven,,java8,,,,
-,robolectric/robolectric,master,,,java8,,,,
+,robolectric/robolectric,master,,,java11,,,,
 ,robospock/RoboSpock,master,,,java8,,,TRUE,Build uses Gradle 3.x
 ,robotemi/sdk,master,,,java8,,,,
 ,robotframework/SwingLibrary,master,maven,,java8,,,,
@@ -32331,7 +32331,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,romix/java-concurrent-hash-trie-map,master,maven,,java8,,,,
 ,rommeldongre/FrrndLease-webapp,master,maven,,java8,,,,
 ,ron-from-nl/FinalCrypt,master,,,java8,,,TRUE,Top-level build tool file is missing
-,ron190/jsql-injection,master,maven,,java8,,,,
+,ron190/jsql-injection,master,maven,,java11,,,,
 ,ronak111091/DeckOfCards,master,,,java8,,,,
 ,ronaldkonjer/BugTrackerJHipster,master,maven,,java8,,,,
 ,ronaldkonjer/jhipster-tasks,master,maven,,java8,,,,
@@ -32348,7 +32348,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,roomorama/Caldroid,master,,,java8,,,,
 ,rootdevelop/LearnN-sa,master,maven,,java8,,,,
 ,rootkiwi/an2linuxclient,master,,,java8,,,,
-,roris/TheFloralBoutique,master,,,java8,,,,
+,roris/TheFloralBoutique,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,rosamobi/k9mail,master,,,java8,,,,
 ,rosberry/RAWF,develop,,,java8,,,,
 ,rosbo/texas-holdem-poker-ai,master,maven,,java8,,,,
@@ -32406,7 +32406,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,rschreijer/lutung,master,maven,,java8,,,,
 ,rsikora-private/jhipster-monolit,master,maven,,java8,,,,
 ,rsilve/smtp-server-noop-netty,main,maven,,java8,,,,
-,rsilve/smtpc,main,maven,,java8,,,,
+,rsilve/smtpc,main,maven,,java11,,,,
 ,rsksmart/bitcoinj-thin,master,maven,,java8,,,,
 ,rsksmart/rskj,master,,,java8,,,TRUE,Error: Could not find or load main class org.gradle.wrapper.GradleWrapperMain (gradlew present but wrapper jar missing)
 ,rsksmart/unitrie-migration,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -32425,7 +32425,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,rszewczyk/wimf,master,,,java8,,,,
 ,rterp/StockChartsFX,master,maven,,java8,,,,
 ,rtoshiro/FullscreenVideoView,master,,,java8,,,,
-,rtto/lutra-mirror,develop,maven,,java8,,,,
+,rtto/lutra-mirror,develop,maven,,java11,,,,
 ,rtugeek/ColorSeekBar,master,,,java8,,,,
 ,rtyley/android-screenshot-lib,master,maven,,java8,,,,
 ,rtyley/mini-git-server,toy-git-server,maven,,java8,,,,
@@ -32464,7 +32464,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,rueian/ncu2015-Conflux,master,,,java8,,,,
 ,rugranvel/jhipsterSample1,master,maven,,java8,,,,
 ,ruifpedro/challenge2019_sportsbook,master,maven,,java8,,,,
-,ruipeng110/conductor,master,,,java8,,,,
+,ruipeng110/conductor,master,,,java11,,,,
 ,ruizrube/databaselearningresearch,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,rulerliu/springboot-seckill,master,maven,,java8,,,,
 ,rumen-scholar/kosmo41_KimCheolEon,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -32504,7 +32504,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,rwanderc/dumb-converter,master,maven,,java8,,,,
 ,rwinch/antora-gradle-plugin,main,,,java8,,,,
 ,rwinch/spring-reactive-intro,master,maven,,java8,,,,
-,rwth-imi/flare-query,master,maven,,java8,,,,
+,rwth-imi/flare-query,master,maven,,java17,,,,
 ,rx21js6/simple-health-log,master,,,java8,,,,
 ,rxmicro/rxmicro,master,maven,,java8,,,,
 ,rxtx/rxtx,development,maven,,java8,,,,
@@ -32730,11 +32730,11 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,sanketgupta07/azure-function-example,main,maven,,java8,,,,
 ,sanluan/PublicCMS,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,sannies/isoviewer,master,maven,,java8,,,,
-,sannies/mp4parser,master,maven,,java8,,,,
+,sannies/mp4parser,master,maven,,java11,,,,
 ,sanogotech/BPMJHipsterCamunda,master,maven,,java8,,,,
 ,sanshengshui/multiTenant,master,maven,,java8,,,,
 ,sant11/hms,master,maven,,java8,,,,
-,santalu/empty-view,master,,,java8,,,,
+,santalu/empty-view,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,santclear/sinal-da-sorte-ws,master,maven,,java8,,,,
 ,santiago-hollmann/sample-enteprise,develop,,,java8,,,,
 ,santinoyanz/Java300,master,,,java8,,,,
@@ -32746,7 +32746,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,santushet/HotSpice,master,maven,,java8,,,,
 ,santushet/barcode_app,master,maven,,java8,,,,
 ,sanwancoder/ztp-redisson-spring-boot-starter,master,maven,,java8,,,,
-,sanyarnd/applocker,master,maven,,java8,,,,
+,sanyarnd/applocker,master,maven,,java11,,,,
 ,sanyarnd/standardpaths,master,maven,,java8,,,,
 ,sanyueruanjian/smpe-admin,main,maven,,java8,,,,
 ,saopayne/grails-nexmo,master,,,java8,,,TRUE,Build uses Gradle 3.x
@@ -32814,7 +32814,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,savy116/scl,master,,,java8,,,,
 ,sawano/spring-examples-json-xml-ws,master,maven,,java8,,,,
 ,saxsalvo/jhipsterSampleApplication,master,maven,,java8,,,,
-,sayems/java.webdriver,development,maven,,java8,,,,
+,sayems/java.webdriver,development,maven,,java11,,,,
 ,saysky/ForestBlog,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,saysky/SENS,master,maven,,java8,,,,
 ,sbajaj7/Ride-Sharing,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -32880,13 +32880,13 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,scenarioo/scenarioo,develop,,,java8,,,,
 ,scenerygraphics/scenery,master,,,java8,,,,
 ,scenerygraphics/sciview,master,,,java8,,,,
-,scgray/jsqsh,master,maven,,java8,,,,
+,scgray/jsqsh,master,maven,,java11,,,,
 ,schaffe/KpiLabs2-2,master,maven,,java8,,,,
 ,schahnie/second-try,master,maven,,java8,,,,
 ,scharron/elasticsearch-river-mysql,master,maven,,java8,,,,
 ,schauder/parameterizedTestsWithRules,master,maven,,java8,,,,
 ,schema-repo/schema-repo,master,maven,,java8,,,,
-,schemaspy/schemaspy,master,maven,,java8,,,,
+,schemaspy/schemaspy,master,maven,,java11,,,,
 ,schezwansoftware/E-book,master,maven,,java8,,,,
 ,schezwansoftware/Migrane,master,maven,,java8,,,,
 ,schezwansoftware/jenkins-cicd,master,maven,,java8,,,,
@@ -32951,7 +32951,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,scijava/swing-checkbox-tree,master,maven,,java8,,,,
 ,scijava/ui-behaviour,master,maven,,java8,,,,
 ,scipr-lab/dizk,master,maven,,java8,,,,
-,scireum/parsii,develop,maven,,java8,,,,
+,scireum/parsii,develop,maven,,java20,,,,
 ,scl2589/Cobook,master,,,java8,,,,
 ,scm-manager/changelog,develop,,,java8,,,,
 ,scm-spain/RxAccountManager,master,,,java8,,,,
@@ -32970,7 +32970,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,scottyab/safetynethelper,main,,,java8,,,,
 ,scottyab/secure-preferences,master,,,java8,,,,
 ,scottyab/showhidepasswordedittext,master,,,java8,,,,
-,scottysinclair/barleydb,master,maven,,java8,,,,
+,scottysinclair/barleydb,master,maven,,java17,,,,
 ,scoute-dich/PDFCreator,master,,,java8,,,,
 ,scouter-project/scouter,master,maven,,java8,,,,
 ,scp504677840/MoveMapLocation,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -32998,7 +32998,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,sdaschner/jaxrs-analyzer,master,maven,,java8,,,,
 ,sdaschner/scalable-coffee-shop,master,,,java8,,,,
 ,sdaskaliesku/fo76tradeServer,master,maven,,java8,,,,
-,sdbg/sdbg,master,maven,,java8,,,,
+,sdbg/sdbg,master,maven,,java11,,,,
 ,sddyljsx/tcp-long-connection-based-on-apache-mina,master,,,java8,,,,
 ,sde-csmu/straps,master,maven,,java8,,,,
 ,sdelamo/build-info-gradle-plugin,master,,,java8,,,,
@@ -33088,7 +33088,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,secretdataz/Minerva,master,,,java8,,,,
 ,secure-software-engineering/FlowDroid,develop,maven,,java8,,,,
 ,secureappmooc/BuggyTheApp,master,,,java8,,,,
-,securityboxes/appsecbox,master,,,java8,,,,
+,securityboxes/appsecbox,master,,,java11,,,,
 ,sedmelluq/jdaction,master,,,java8,,,TRUE,Build uses Gradle 3.x
 ,sedmelluq/mass-relocator,master,,,java8,,,TRUE,Build uses Gradle 3.x
 ,sedovalx/gradle-aspectj-binary,master,,,java8,,,,
@@ -33234,7 +33234,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,sfdc-excel-macros/springmvc-test1,main,maven,,java8,,,,
 ,sfdc-excel-macros/suzysheep,main,maven,,java8,,,,
 ,sferrazjr/anagram,master,maven,,java8,,,,
-,sflpro/notifier,master,maven,,java8,,,,
+,sflpro/notifier,master,maven,,java11,,,,
 ,sfoubert/jhipster-online-application,master,maven,,java8,,,,
 ,sfqin/springboots-mongodbs,master,maven,,java8,,,,
 ,sfsheng0322/MarqueeView,master,,,java8,,,,
@@ -33320,7 +33320,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,shapesecurity/bandolier,es2018,maven,,java8,,,,
 ,shapesecurity/salvation,main,maven,,java8,,,,
 ,shapesecurity/shape-functional-java,main,maven,,java8,,,,
-,shapesecurity/shift-java,es2018,maven,,java8,,,,
+,shapesecurity/shift-java,es2018,maven,,java11,,,,
 ,shapesecurity/shift-semantics-java,es2017,maven,,java8,,,,
 ,shapyz/JHash,master,maven,,java8,,,,
 ,sharadregoti/test-guacamole-client,poc-branch,maven,,java8,,,,
@@ -33448,7 +33448,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,shiv-u/MyMovies,master,,,java8,,,,
 ,shiv-u/TourdeKarnataka,master,,,java8,,,,
 ,shiv-u/business_card,master,,,java8,,,,
-,shiv-u/collab,development,,,java8,,,,
+,shiv-u/collab,development,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,shiv-u/kaunbanegacrorepati,master,,,java8,,,,
 ,shiv-u/weekchallenge,master,,,java8,,,,
 ,shivamdawas/shivam,master,maven,,java8,,,,
@@ -33535,7 +33535,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,sifron/KristenKlock,master,,,java8,,,,
 ,siggijons/dex-methods,master,,,java8,,,,
 ,sigmah-dev/sigmah,master,maven,,java8,,,,
-,signaflo/java-timeseries,master,,,java8,,,,
+,signaflo/java-timeseries,master,,,java8,,,TRUE,Gradle wrapper 4.8 is not supported
 ,signalapp/BitHub,master,maven,,java8,,,,
 ,signalapp/CLAServer,master,maven,,java8,,,,
 ,signalapp/PushServer,master,maven,,java8,,,,
@@ -33684,7 +33684,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,sk89q/WorldEdit,master,,,java8,,,,
 ,sk89q/warmroast,master,maven,,java8,,,,
 ,skabashnyuk/petclinic,master,maven,,java8,,,,
-,skadistats/clarity,master,maven,,java8,,,,
+,skadistats/clarity,master,maven,,java11,,,,
 ,skadistats/clarity-examples,master,maven,,java8,,,,
 ,skaengus2012/N-java,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,skaspok/coconutPlaylist,master,maven,,java8,,,,
@@ -33747,7 +33747,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,skyywj/community-square,master,maven,,java8,,,,
 ,slabiak/AppointmentScheduler,develop,maven,,java8,,,,
 ,slachiewicz/GUS-Teryt-Parser,master,maven,,java8,,,,
-,slackhq/EitherNet,main,,,java8,,,,
+,slackhq/EitherNet,main,,,java11,,,,
 ,slackhq/kaldb,master,maven,,java8,,,,
 ,slaclau/Diving,develop,,,java8,,,,
 ,slamdev/js-builder-gradle-plugin,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
@@ -33845,7 +33845,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,smoketurner/dropwizard-money,master,maven,,java8,,,,
 ,smoketurner/dropwizard-riak,master,maven,,java8,,,,
 ,smoketurner/graphiak,master,maven,,java8,,,,
-,smoketurner/uploader,master,maven,,java8,,,,
+,smoketurner/uploader,master,maven,,java11,,,,
 ,smola/galimatias,master,maven,,java8,,,,
 ,smolakalaLoginsoft/Spring-Boot-Blog-REST-API,main,maven,,java8,,,,
 ,smolakalaLoginsoft/TestClient,main,maven,,java8,,,,
@@ -33885,7 +33885,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,snorkobilov/CalculatorTemp,master,,,java8,,,,
 ,snowWave1995/toutiao,master,maven,,java8,,,,
 ,snowdream/java-version-check,master,,gradle,java8,,,,
-,snowdrop/crud-example,sb-2.5.x,maven,,java8,,,,
+,snowdrop/crud-example,sb-2.5.x,maven,,java11,,,,
 ,snowdrop/health-check-example,sb-2.5.x,maven,,java8,,,,
 ,snowdrop/rest-http-example,sb-2.5.x,maven,,java8,,,,
 ,snowdrop/snowdrop-cloud-devex,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -33920,10 +33920,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,sockeqwe/SwipeBack,master,,,java8,,,,
 ,sockeqwe/Vaadin-MVP-Lite,master,maven,,java8,,,,
 ,sockeqwe/annotationprocessing101,master,,,java8,,,TRUE,Top-level build tool file is missing
-,sockeqwe/debugoverlay,master,,,java8,,,,
+,sockeqwe/debugoverlay,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,sockeqwe/fragmentargs,master,maven,,java8,,,,
 ,sockeqwe/mosby,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
-,sockeqwe/mosby-conductor,master,,,java8,,,,
+,sockeqwe/mosby-conductor,master,,,java8,,,TRUE,Gradle wrapper 4.2.1 is not supported
 ,sockeqwe/sqlbrite-dao,master,,,java8,,,,
 ,socketio/socket.io-client-java,master,maven,,java8,,,,
 ,socrat2012/jhipster-sample-application,master,maven,,java8,,,,
@@ -33998,7 +33998,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,somehowchris/gibsso-java-adressverwaltung-v2,master,maven,,java8,,,,
 ,somehowchris/gibsso-java-sorting-exam,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,someok/gradle-multi-project-example,master,,,java8,,,,
-,someth2say/taijitu,master,maven,,java8,,,,
+,someth2say/taijitu,master,maven,,java11,,,,
 ,somowhere/albedo,master,maven,,java8,,,,
 ,somowhere/albedo-boot-freemaker,master,maven,,java8,,,,
 ,son7211/testdi,master,,,java8,,,,
@@ -34012,7 +34012,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,sonaldesai1234/CarBookingProject,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,sonalgoyal/hiho,master,maven,,java8,,,,
 ,sonar-intellij-plugin/sonar-intellij-plugin,master,,,java8,,,,
-,sonar-perl/sonar-perl,master,,,java8,,,,
+,sonar-perl/sonar-perl,master,,,java11,,,,
 ,sonatype-nexus-community/scan-gradle-plugin,main,,,java8,,,,
 ,sonatype/chef-nexus-repository-manager,main,maven,,java8,,,,
 ,sonatype/codestyle,main,maven,,java8,,,,
@@ -34077,7 +34077,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,sorcix/sIRC,master,maven,,java8,,,,
 ,sorend/bitbucketserver-webhook-app,master,,,java8,,,,
 ,sorend/bitbucketserver-webhook-dispatcher,main,,,java8,,,,
-,sorend/filemirrorsync,master,,,java8,,,,
+,sorend/filemirrorsync,master,,,java8,,,TRUE,Gradle wrapper 4.8 is not supported
 ,sorend/fuzzy4j,master,,,java8,,,,
 ,sorend/gstftpd-server,master,,,java8,,,,
 ,sorend/jgrapht-sna,master,,,java8,,,,
@@ -34116,7 +34116,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,sourcegraph/srclib-java,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,sourcemuse/GradleMongoPlugin,master,,,java8,,,,
 ,sourcey/materiallogindemo,master,,,java8,,,,
-,souris-dev/samosac-jvm,main,maven,,java8,,,,
+,souris-dev/samosac-jvm,main,maven,,java11,,,,
 ,sousacruz/modeling,master,maven,,java8,,,,
 ,souteh/jhipster-sample-application,master,maven,,java8,,,,
 ,souteh/jhipsterSampleApplication,master,maven,,java8,,,,
@@ -34150,7 +34150,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,speakeasy/CopyCat,master,maven,,java8,,,,
 ,spearce/jgit,master,maven,,java8,,,,
 ,spedepekka/skilldemon-server,master,maven,,java8,,,,
-,speedment/speedment,master,maven,,java8,,,,
+,speedment/speedment,master,maven,,java11,,,,
 ,speedwing/log4j-cloudwatch-appender,master,maven,,java8,,,,
 ,spengilley/ActivityFragmentMVP,master,,,java8,,,,
 ,spengreb/gradle-openshift-plugin,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
@@ -34215,7 +34215,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,spotify/cassandra-reaper,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,spotify/completable-futures,master,maven,,java8,,,,
 ,spotify/dbeam,master,maven,,java11,,,,
-,spotify/dns-java,master,maven,,java8,,,,
+,spotify/dns-java,master,maven,,java11,,,,
 ,spotify/docgenerator,master,maven,,java8,,,,
 ,spotify/docker-client,master,maven,,java8,,,,
 ,spotify/docker-maven-plugin,master,maven,,java8,,,,
@@ -34505,7 +34505,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,square/MimicAndRephrase,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,square/RxIdler,master,,,java8,,,,
 ,square/android-times-square,master,,,java11,,,,
-,square/anvil,main,,,java8,,,,
+,square/anvil,main,,,java11,,,,
 ,square/assertj-android,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,square/auto-value-redacted,master,,,java8,,,,
 ,square/burst,master,maven,,java8,,,,
@@ -34520,7 +34520,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,square/flow,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,square/gifencoder,master,maven,,java8,,,,
 ,square/haha,master,maven,,java8,,,,
-,square/hephaestus,main,,,java8,,,,
+,square/hephaestus,main,,,java11,,,,
 ,square/in-app-payments-android-quickstart,master,,,java8,,,,
 ,square/javapoet,master,maven,,java8,,,,
 ,square/jna-gmp,master,maven,,java8,,,,
@@ -34545,7 +34545,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,square/reader-sdk-android-quickstart,master,,,java11,,,,
 ,square/retrofit,master,,,java8,,,,
 ,square/seismic,master,maven,,java8,,,,
-,square/sqlbrite,trunk,,,java11,,,,
+,square/sqlbrite,trunk,,,java11,,,TRUE,Gradle wrapper 4.4 is not supported
 ,square/square-java-sdk,master,maven,,java8,,,,
 ,square/squickpic,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,square/subzero,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -34554,7 +34554,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,square/wire,master,,,java11,,,,
 ,square/workflow,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,square/workflow-android-template,master,,,java8,,,,
-,square/workflow-kotlin,main,,,java8,,,,
+,square/workflow-kotlin,main,,,java11,,,,
 ,squedgy/faris-test-plugin,master,,,java8,,,,
 ,squeek502/AppleSkin,1.16-forge,,,java8,,,,
 ,sraghupatrini/UserRegistration,main,,,java8,,,TRUE,Top-level build tool file is missing
@@ -34604,7 +34604,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ssavageVT-zz/spookywb,master,maven,,java8,,,,
 ,sscarduzio/elasticsearch-readonlyrest-plugin,develop,,,java8,,,TRUE,Top-level build tool file is missing
 ,sscpac/swif,master,maven,,java8,,,,
-,sshahine/JFoenix,master,,,java8,,,,
+,sshahine/JFoenix,master,,,java8,,,TRUE,Gradle wrapper 4.2.1 is not supported
 ,sshishe/jsdeodorant,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,sshoogr/sshoogr-parent,main,,,java8,,,,
 ,sshtools/j2ssh-maverick,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -34642,7 +34642,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,stammatime/test-app,master,maven,,java8,,,,
 ,stammatime/test_app,master,maven,,java8,,,,
 ,stamp6608/wildfirechat,master,,,java8,,,TRUE,Top-level build tool file is missing
-,standiel/hello-world,master,maven,,java8,,,,
+,standiel/hello-world,master,maven,,java11,,,,
 ,stanford-futuredata/macrobase,master,maven,,java8,,,,
 ,stanfordnlp/CoreNLP,main,,,java8,,,TRUE,Build uses Gradle 3.x
 ,stanfordnlp/phrasal,master,,gradle,java8,,,,
@@ -34662,7 +34662,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,stateIs0/Lu-Rpc,master,maven,,java8,,,,
 ,stateIs0/lu-raft-kv,master,maven,,java8,,,,
 ,statefulj/statefulj,master,maven,,java8,,,,
-,stateless4j/stateless4j,master,maven,,java8,,,,
+,stateless4j/stateless4j,master,maven,,java11,,,,
 ,status-im/energy-efficient-bok,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,status-im/keycard-connect,master,,,java8,,,,
 ,status-im/status-keycard-java,master,,,java8,,,,
@@ -34670,7 +34670,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,stavmars/socioscope,master,maven,,java8,,,,
 ,stavmars/youwho,master,maven,,java8,,,,
 ,stden/xSandbox,master,maven,,java8,,,,
-,stdunbar/jaxrs-sample,master,maven,,java8,,,,
+,stdunbar/jaxrs-sample,master,maven,,java11,,,,
 ,stealthcopter/AndroidNetworkTools,main,,,java8,,,,
 ,steelkiwi/cropiwa,master,,,java8,,,,
 ,steelxiang/chatroom,master,maven,,java8,,,,
@@ -34751,7 +34751,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,stevenzhangst/jhipster-sample-application,master,maven,,java8,,,,
 ,stevesaliman/gradle-cobertura-plugin,master,,,java8,,,,
 ,stevesaliman/gradle-properties-plugin,master,,,java8,,,,
-,stevespringett/Alpine,master,maven,,java8,,,,
+,stevespringett/Alpine,master,maven,,java17,,,,
 ,stevespringett/CPE-Parser,master,maven,,java8,,,,
 ,stevespringett/headlines,master,maven,,java8,,,,
 ,steveteske/FinancialTracking,master,maven,,java8,,,,
@@ -34770,7 +34770,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,stleary/JSON-java,master,,,java8,,,,
 ,stnwtr/gradle-secrets-plugin,main,,,java8,,,,
 ,stockgeeks/spring-kafka-poison-pill,master,maven,,java8,,,,
-,stoicflame/enunciate,master,maven,,java8,,,,
+,stoicflame/enunciate,master,maven,,java11,,,,
 ,stoicflame/enunciate-gradle,master,,,java8,,,,
 ,stoicflame/enunciate-sample,master,maven,,java8,,,,
 ,stonedong/GroupIcon,master,,,java8,,,,
@@ -34802,7 +34802,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,streamsupport/streamsupport,master,,,java8,,,,
 ,streamxhub/jobx,master,maven,,java8,,,,
 ,streetlightvision/versioneer,master,,,java8,,,TRUE,Build uses Gradle 2.x
-,strimzi/drain-cleaner,main,maven,,java8,,,,
+,strimzi/drain-cleaner,main,maven,,java11,,,,
 ,strimzi/strimzi-kafka-bridge,main,maven,,java8,,,,
 ,strimzi/strimzi-kafka-operator,main,maven,,java11,,,,
 ,stringbasic/java-exercises,main,,,java8,,,,
@@ -34912,7 +34912,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,sunyatas/NetStatusBus,master,,,java8,,,,
 ,sunysen/naivechain,master,maven,,java8,,,,
 ,supabase-community/gotrue-java,master,maven,,java8,,,,
-,supaldubey/blog-server,master,maven,,java8,,,,
+,supaldubey/blog-server,master,maven,,java11,,,,
 ,super-csv/super-csv,master,maven,,java8,,,,
 ,superSp/RulerView,master,,,java8,,,,
 ,superStar321/jhipster,master,maven,,java8,,,,
@@ -34982,7 +34982,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,swachil/fettlepath,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,swagger-api/swagger-codegen,master,,,java8,,,,
 ,swagger-api/swagger-converter,master,maven,,java8,,,,
-,swagger-api/swagger-core,master,,,java8,,,,
+,swagger-api/swagger-core,master,,,java11,,,,
 ,swagger-api/swagger-inflector,master,maven,,java8,,,,
 ,swagger-api/swagger-parser,master,maven,,java8,,,,
 ,swagger-api/swagger-socket,master,maven,,java8,,,,
@@ -34990,7 +34990,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,swagger-api/validator-badge,master,maven,,java8,,,,
 ,swalihtk/firebase-chat-app-android,main,,,java8,,,,
 ,swallez/jmh-couchbase-keyvaluestatus,master,maven,,java8,,,,
-,swanaka/ship-simulation,master,,,java8,,,,
+,swanaka/ship-simulation,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,swanysimon/gradleShowTestRunsPlugin,master,,,java8,,,,
 ,swapnibble/EosCommander,master,,,java8,,,,
 ,swapnil1104/CurveGraphView,master,,,java8,,,,
@@ -35024,7 +35024,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,syed-ahamed04/jhipster-sample-application,master,maven,,java8,,,,
 ,syeedibnfaiz/libsvm-java-kernel,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,sygnowski/doer,main,,,java8,,,,
-,sygnowski/flink-doto-app,master,maven,,java8,,,,
+,sygnowski/flink-doto-app,master,maven,,java11,,,,
 ,syhrus/OrganiserAppAssignment,master,,,java8,,,,
 ,syl2017/LoginMVP,master,,,java8,,,,
 ,syl20bnr/jobgenerator-jenkins,master,maven,,java8,,,,
@@ -35072,9 +35072,9 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,synopsys-arc-oss/extra-tool-installers-plugin,master,maven,,java8,,,,
 ,synopsys-arc-oss/job-restrictions-plugin,master,maven,,java8,,,,
 ,synopsys-arc-oss/ownership-plugin,master,maven,,java8,,,,
-,synthetichealth/synthea,master,,,java8,,,,
+,synthetichealth/synthea,master,,,java11,,,,
 ,synyx/messagesource,master,maven,,java8,,,,
-,synyx/urlaubsverwaltung,main,maven,,java8,,,,
+,synyx/urlaubsverwaltung,main,maven,,java11,,,,
 ,syrjs/core,develop,,,java8,,,TRUE,Top-level build tool file is missing
 ,sysEx/sitemanager-webapp,master,maven,,java8,,,,
 ,sysgears/grain-gradle-plugin,master,,,java8,,,,
@@ -35171,7 +35171,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,talk2stars/jiuzhangquanzhanke,master,maven,,java8,,,,
 ,talsma-ict/context-propagation,develop,maven,,java8,,,,
 ,talsma-ict/enumerables,develop,maven,,java8,,,,
-,talsma-ict/lazy4j,develop,maven,,java8,,,,
+,talsma-ict/lazy4j,develop,maven,,java11,,,,
 ,talsma-ict/reflection,develop,maven,,java8,,,,
 ,talsma-ict/umldoclet,develop,maven,,java8,,,,
 ,taltstidl/AppCompat-Extension-Library,master,,,java8,,,,
@@ -35232,7 +35232,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,tarantool/cartridge-java,master,maven,,java8,,,,
 ,tarcisiofilo/sicapuc20201,master,maven,,java8,,,,
 ,tarek-bochkati/jFX,master,,,java8,,,TRUE,Top-level build tool file is missing
-,tarek360/Instacapture,master,,,java8,,,,
+,tarek360/Instacapture,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,tarek360/Material-Animation-Samples,master,,,java8,,,,
 ,tarekayar/MyApp,master,maven,,java8,,,,
 ,tarekayar/SampleApplication,master,maven,,java8,,,,
@@ -35324,7 +35324,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,techdev-solutions/trackr-backend,development,,,java8,,,,
 ,techery/ProperRatingBar,master,,,java8,,,,
 ,techery/presenta,master,,,java8,,,,
-,techery/progresshint,master,,,java8,,,,
+,techery/progresshint,master,,,java8,,,TRUE,Gradle wrapper 4.9 is not supported
 ,technical-rex/spring-security-jwt,master,maven,,java8,,,,
 ,technoir42/aar-publish-plugin,master,,,java8,,,,
 ,technologynexus/azurefunction-test,main,maven,,java8,,,,
@@ -35384,7 +35384,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,termux/termux-float,master,,,java8,,,,
 ,termux/termux-tasker,master,,,java8,,,,
 ,termux/termux-widget,master,,,java8,,,,
-,terraframe/Runway-SDK,master,maven,,java8,,,,
+,terraframe/Runway-SDK,master,maven,,java11,,,,
 ,terre-virtuelle/navisu,master,,,java8,,,,
 ,terrier-org/terrier-core,5.x,maven,,java11,,,,
 ,terrorizer1980/senzing-api-server,master,maven,,java11,,,,
@@ -35467,7 +35467,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,theindianappguy/Lamp_Store_App_UI,master,,,java8,,,,
 ,theisuru/sentiment-tagger,master,maven,,java8,,,,
 ,thekirankumar/carstream-android-auto,master,,,java8,,,,
-,thekrakken/java-grok,master,,,java8,,,,
+,thekrakken/java-grok,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,theksmith/CarBusInterface,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,themadcreator/rabinfingerprint,master,maven,,java8,,,,
 ,themansouriahs/comic-viewer,master,,,java8,,,,
@@ -35488,7 +35488,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,thethuz/medium,master,maven,,java8,,,,
 ,thetlwinoo/resource-server,master,maven,,java8,,,,
 ,thewalk/jhipsterSampleApplication,master,maven,,java8,,,,
-,thewca/tnoodle,master,,,java8,,,,
+,thewca/tnoodle,master,,,java11,,,,
 ,thewriterl/jhipster-sample,master,maven,,java8,,,,
 ,theywa/bbvet,master,maven,,java8,,,,
 ,thfhongfeng/PineAppRtc,master,,,java8,,,,
@@ -35535,7 +35535,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,thirtsoft/passerelle,master,maven,,java8,,,,
 ,thirtyai/nezha-starters,master,maven,,java8,,,,
 ,thiscitizenis/citizen-sdk-java,master,maven,,java8,,,,
-,thisxulz/RedMQ,master,maven,,java8,,,,
+,thisxulz/RedMQ,master,maven,,java17,,,,
 ,thivyanWhy/Gugsi-Musical-Enterprises,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,thjr/hass-digitraffic,master,maven,,java8,,,,
 ,thomas-lehmann-private/hyperion-task-processor,main,maven,,java8,,,,
@@ -35547,7 +35547,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,thomasdarimont/embedded-spring-boot-keycloak-server,master,maven,,java8,,,,
 ,thomasdarimont/keycloak-health-checks,master,maven,,java8,,,,
 ,thomasdarimont/spring-boot-keycloak-server-example,master,maven,,java8,,,,
-,thomasekyle/simpleapi,master,maven,,java8,,,,
+,thomasekyle/simpleapi,master,maven,,java11,,,,
 ,thomasguo/hiSampleApplication,master,maven,,java8,,,,
 ,thomashaertel/jhipsterSampleApplication,master,maven,,java8,,,,
 ,thomashan/gradle-environment-config,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
@@ -35603,7 +35603,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,thuguerre/WebSiteQuickAddingForTodoist,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,thulab/iotdb-benchmark,master,maven,,java8,,,,
 ,thulasipuppala/FaeBoo,master,maven,,java8,,,,
-,thundernest/k-9,main,,,java8,,,,
+,thundernest/k-9,main,,,java11,,,,
 ,thunlp/THULAC-Java,master,,gradle,java8,,,,
 ,thunlp/THUTag,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,thurderbird521/findmusic,master,maven,,java8,,,,
@@ -35627,7 +35627,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,tian-yuan/RuleEngin,master,maven,,java8,,,,
 ,tianhongjie/jhipsterSampleApp,master,maven,,java8,,,,
 ,tianma8023/SmsCode,master,,,java8,,,,
-,tiann/FreeReflection,master,,,java8,,,,
+,tiann/FreeReflection,master,,,java8,,,TRUE,Gradle wrapper 4.8.1 is not supported
 ,tiann/understand-plugin-framework,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,tianshouzhi/jhipsterSampleApplication,master,maven,,java8,,,,
 ,tiantiangao/guava-study,master,maven,,java8,,,,
@@ -35651,7 +35651,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,tienph91/microapp,main,maven,,java8,,,,
 ,tienph91/search,main,maven,,java8,,,,
 ,tifezh/KChartView,master,,,java8,,,,
-,tigefa4u/android-tigefa,master,,,java8,,,,
+,tigefa4u/android-tigefa,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,tigerst/presto-udfs,master,maven,,java8,,,,
 ,tigrajhipster/jhipster,master,maven,,java8,,,,
 ,tigrisdata/tigris-client-java,main,maven,,java8,,,,
@@ -35716,7 +35716,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,tjake/Solandra,solandra,maven,,java8,,,,
 ,tjake/rbm-dbn-mnist,master,maven,,java8,,,,
 ,tjerkw/Android-SlideExpandableListView,master,,gradle,java8,,,,
-,tjysdsg/cs308-ooga,master,maven,,java8,,,,
+,tjysdsg/cs308-ooga,master,maven,,java17,,,,
 ,tjysdsg/cs308-slogo,master,maven,,java8,,,,
 ,tk1cntt/drop-shipping-backend,master,maven,,java8,,,,
 ,tk1lz-six/jhipster-sample-application,master,maven,,java8,,,,
@@ -35739,7 +35739,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,tltv/gantt,master,maven,,java8,,,,
 ,tmanev/quis-listing,master,maven,,java8,,,,
 ,tmfg/digitraffic-marine,master,maven,,java8,,,,
-,tmfg/digitraffic-rail,master,maven,,java8,,,,
+,tmfg/digitraffic-rail,master,maven,,java11,,,,
 ,tmiyamon/gradle-config,master,,,java8,,,TRUE,Build uses Gradle 3.x
 ,tmiyamon/gradle-mdicons,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,tmjl/jhipsterSampleApplication,master,maven,,java8,,,,
@@ -35820,7 +35820,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,tomcio-programuje/jhipsterSampleApplication,master,maven,,java8,,,,
 ,tomdesair/tus-java-server,master,maven,,java8,,,,
 ,tomdz/sphinx-maven,master,maven,,java8,,,,
-,tomek199/elo-rating,master,,,java8,,,,
+,tomek199/elo-rating,master,,,java8,,,TRUE,Gradle wrapper 4.8.1 is not supported
 ,tomighty/tomighty,master,maven,,java8,,,,
 ,tomitribe/tomee-jaxrs-starter-project,master,,,java8,,,,
 ,tomjshore/cv-site,master,maven,,java8,,,,
@@ -35848,7 +35848,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,tongfgye/adminSystem,master,maven,,java8,,,,
 ,tongpi/jhipster_angular_jwt_app,master,maven,,java8,,,,
 ,tongqqiu/maven4enterprise,develop,maven,,java8,,,,
-,tonihele/OpenKeeper,master,,,java8,,,,
+,tonihele/OpenKeeper,master,,,java17,,,,
 ,tonikelope/megabasterd,master,maven,,java8,,,,
 ,tonilopezmr/Game-of-Thrones,master,,,java8,,,,
 ,tonilxm/whatscover,dev,maven,,java8,,,,
@@ -35871,10 +35871,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,top9teen/Agent-Pro2-master,master,maven,,java8,,,,
 ,topsale/spring-boot-samples,master,maven,,java8,,,,
 ,toptal/jvm-monitoring-agent,master,,,java8,,,TRUE,Top-level build tool file is missing
-,torakiki/pdfsam,master,maven,,java8,,,,
+,torakiki/pdfsam,master,maven,,java20,,,,
 ,torakiki/sejda,master,maven,,java8,,,,
 ,toranainc/i-ced-q,master,maven,,java8,,,,
-,tordanik/OSM2World,master,maven,,java8,,,,
+,tordanik/OSM2World,master,maven,,java17,,,,
 ,torgcrm/TorgCRM-Server,master,maven,,java8,,,,
 ,torinnguyen/broadlink-android,master,,,java8,,,,
 ,torito/jhipster_samples,master,maven,,java8,,,,
@@ -35978,7 +35978,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,trimou/trimou,master,maven,,java8,,,,
 ,trinodb/tempto,master,maven,,java8,,,,
 ,trinodb/tpch,master,maven,,java8,,,,
-,trinodb/trino,master,maven,,java8,,,,
+,trinodb/trino,master,maven,,java11,,,,
 ,trinodb/trino-hadoop-apache,master,maven,,java8,,,,
 ,tripadvisor/android-clockseekbar,master,,,java8,,,,
 ,tripadvisor/elasticsearch-remove-token-filter,master,maven,,java8,,,,
@@ -35989,7 +35989,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,triplethreats/eqwal-sharez,master,maven,,java8,,,,
 ,tripluo/jrouter,master,maven,,java8,,,,
 ,tripodsan/SimplyUtilities,master,maven,,java8,,,,
-,trishagee/sense,main,,,java8,,,,
+,trishagee/sense,main,,,java11,,,,
 ,trishika/DroidUPnP,master,,,java8,,,TRUE,Build uses Gradle 3.x
 ,trivago/Heimdall.droid,master,,,java8,,,,
 ,trivago/jcha,master,maven,,java8,,,,
@@ -36103,7 +36103,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,turbomanage/basic-http-client,master,maven,,java8,,,,
 ,turbomanage/storm-gen,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,turing-tech/MaterialScrollBar,master,,,java8,,,,
-,turkraft/spring-filter,main,maven,,java8,,,,
+,turkraft/spring-filter,main,maven,,java11,,,,
 ,turn/splicer,master,,,java8,,,,
 ,turneand/apjt-web-crawler,main,maven,,java8,,,,
 ,turnupdigital/tudteststoreapp,master,maven,,java8,,,,
@@ -36124,7 +36124,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,tvprasad/MonolithicApp,master,maven,,java8,,,,
 ,tvprasad/jhipsterSampleApplication,master,maven,,java8,,,,
 ,tvrenamer/tvrenamer,master,,gradle,java8,,,,
-,twasyl/SlideshowFX,master,,,java8,,,,
+,twasyl/SlideshowFX,master,,,java17,,,,
 ,twasyl/jstackfx,master,,,java8,,,,
 ,tweakers/objectpool-benchmarks,master,maven,,java8,,,,
 ,twig/android-low-light-theme-switcher,master,,gradle,java8,,,,
@@ -36143,7 +36143,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,twitch4j/nitro-codegen,master,,,java8,,,,
 ,twitch4j/sdcf4j-twitch,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,twitch4j/streamlabs4j,master,,,java8,,,,
-,twitch4j/twitch4j,master,,,java8,,,,
+,twitch4j/twitch4j,master,,,java11,,,,
 ,twitch4j/twitch4j-chatbot,master,,,java8,,,,
 ,twitch4j/twitch4j-chatbot-kotlin,master,,,java8,,,,
 ,twitch4j/twitch4j-fabric,master,,,java8,,,,
@@ -36239,7 +36239,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,uber/RIBs,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,uber/RxDogTag,main,,,java8,,,,
 ,uber/android-template,master,,,java8,,,,
-,uber/artist,master,,,java8,,,,
+,uber/artist,master,,,java8,,,TRUE,Gradle wrapper 4.7 is not supported
 ,uber/concurrency-loadbalancer,main,maven,,java8,,,,
 ,uber/crumb,main,,,java8,,,,
 ,uber/lint-checks,main,,,java8,,,,
@@ -36247,7 +36247,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,uber/okbuck,master,,,java8,,,,
 ,uber/phabricator-jenkins-plugin,master,,,java8,,,,
 ,uber/piranha,master,,,java8,,,TRUE,Top-level build tool file is missing
-,uber/rides-android-sdk,master,,,java8,,,,
+,uber/rides-android-sdk,master,,,java8,,,TRUE,Gradle wrapper 4.9 is not supported
 ,uber/rides-java-sdk,master,,,java8,,,,
 ,uber/stylist,master,,,java8,,,,
 ,uber/uReplicator,master,maven,,java8,,,,
@@ -36263,7 +36263,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ubiratansoares/deeplinking-appindexing-tutorial,master,,,java8,,,,
 ,ubiratansoares/reactive-architectures-playground,master,,,java8,,,,
 ,ubiratansoares/rxassertions,master,,,java8,,,,
-,ubleipzig/iiif-producer,master,,,java8,,,,
+,ubleipzig/iiif-producer,master,,,java11,,,,
 ,ucbrise/confluo,single-machine,,,java8,,,TRUE,Top-level build tool file is missing
 ,uccmawei/FingerprintIdentify,master,,,java8,,,,
 ,ucdavis/ipa-web,master,,,java8,,,,
@@ -36322,7 +36322,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,ujcms/jspbb,master,maven,,java8,,,,
 ,ujcms/ujcms,master,maven,,java8,,,,
 ,ujjwaldp07/jhipsterSampleApplication,master,maven,,java8,,,,
-,ujwal-coditas/MultiLamp,master,,,java8,,,,
+,ujwal-coditas/MultiLamp,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,uki354/uber,main,maven,,java8,,,,
 ,ukiuni/call-remote-job-plugin,master,maven,,java8,,,,
 ,ukiuni/monitor-remote-job-plugin,master,maven,,java8,,,,
@@ -36349,7 +36349,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,umangburman/Navigation-Drawer-With-Navigation-Component,master,,,java8,,,,
 ,umangparekh001/yoUVcode,master,maven,,java8,,,,
 ,umano/AndroidSlidingUpPanel,master,,,java8,,,TRUE,Build uses Gradle 3.x
-,umbmadina/ChildVac,master,,,java8,,,,
+,umbmadina/ChildVac,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,umerov1999/instagrabber,master,,,java8,,,,
 ,umeshh/my-aws-sdk,master,maven,,java8,,,,
 ,umich-michr/h2-gradle-plugin,master,,,java8,,,,
@@ -36400,7 +36400,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,uom-daris/daris-commons-net-plugin,master,maven,,java8,,,,
 ,up1/hello-jhipster,master,maven,,java8,,,,
 ,up1/soa_group7,master,,,java8,,,TRUE,Top-level build tool file is missing
-,update4j/update4j,master,maven,,java8,,,,
+,update4j/update4j,master,maven,,java11,,,,
 ,updeshxp/scrcpy-android,master,,,java8,,,,
 ,upen4a3/tcfhackathonblockchian,master,maven,,java8,,,,
 ,upgundecha/ifttt-build-notifier,master,maven,,java8,,,,
@@ -36434,7 +36434,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,usernameyangyan/Collection-Android,master,,,java8,,,,
 ,userstan/JHipster,master,maven,,java8,,,,
 ,usethesource/capsule,main,,,java8,,,,
-,usethesource/rascal,main,maven,,java8,,,,
+,usethesource/rascal,main,maven,,java11,,,,
 ,usethesource/rascal-eclipse,main,maven,,java8,,,,
 ,usgs/earthquake-event-ws-client,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,ushahidi/Ushahidi_Java,develop,,,java8,,,TRUE,Top-level build tool file is missing
@@ -36482,9 +36482,9 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,vaadin/archetype-application-example,master,maven,,java8,,,,
 ,vaadin/base-starter-gradle,v23,,,java8,,,,
 ,vaadin/base-starter-spring-gradle,v23,,,java8,,,,
-,vaadin/bookstore-example,v23,maven,,java8,,,,
+,vaadin/bookstore-example,v23,maven,,java11,,,,
 ,vaadin/cdi-tutorial,master,maven,,java8,,,,
-,vaadin/ce-demo,master,maven,,java8,,,,
+,vaadin/ce-demo,master,maven,,java11,,,,
 ,vaadin/charts,master,maven,,java8,,,,
 ,vaadin/component-starter-flow,v23,maven,,java8,,,,
 ,vaadin/cookbook,master,maven,,java17,,,,
@@ -36523,7 +36523,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,vaadin/skeleton-starter-flow-cdi,v23,maven,,java8,,,,
 ,vaadin/skeleton-starter-flow-spring,v23,maven,,java8,,,,
 ,vaadin/spring,12.4,maven,,java8,,,,
-,vaadin/testbench-demo,master,maven,,java8,,,,
+,vaadin/testbench-demo,master,maven,,java17,,,,
 ,vaadin/touchkit,master,maven,,java8,,,,
 ,vaadin/tree-grid,master,maven,,java8,,,,
 ,vaadin/trippy,master,maven,,java8,,,,
@@ -36710,7 +36710,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,verehu/SweetCamera,master,,,java8,,,,
 ,verehu/SweetMusicPlayer,master,,,java8,,,,
 ,verezragna/diploma,master,maven,,java8,,,,
-,verhas/License3j,master,maven,,java8,,,,
+,verhas/License3j,master,maven,,java11,,,,
 ,verhas/fluflu,master,maven,,java8,,,,
 ,verilylifesciences/genomewarp,main,maven,,java8,,,,
 ,veritas-toolkit/assessment-tool,master,maven,,java8,,,,
@@ -36866,7 +36866,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,vinayvarshith/bankapp,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,vinc3m1/DragSortAdapter,main,,,java8,,,,
 ,vinc3m1/RoundedImageView,main,,,java8,,,TRUE,Build uses Gradle 3.x
-,vinc3m1/nowdothis,main,,,java8,,,,
+,vinc3m1/nowdothis,main,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,vince-styling/Netroid,dev,,,java8,,,,
 ,vince-styling/aSQLitePlus-android,master,maven,,java8,,,,
 ,vinceajcs/SpaceRaiders,master,,,java8,,,,
@@ -36949,7 +36949,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,vityay17/flickrPhotoList,master,maven,,java8,,,,
 ,vityay17/jhipsterElasticSearchSample,master,maven,,java8,,,,
 ,vivali/ManaProject,master,maven,,java8,,,,
-,vivanks/nTech-NewsReader,master,,,java8,,,,
+,vivanks/nTech-NewsReader,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,vivchar/RendererRecyclerViewAdapter,master,,,java8,,,,
 ,vivek/capability-annotation,master,maven,,java8,,,,
 ,vivek2575/web_application,master,maven,,java8,,,,
@@ -37023,7 +37023,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,vmware/software-forensic-kit,master,maven,,java8,,,,
 ,vmware/test-operations,master,maven,,java8,,,,
 ,vmware/transport-java,main,,,java8,,,,
-,vmware/upgrade-framework,master,maven,,java8,,,,
+,vmware/upgrade-framework,master,maven,,java11,,,,
 ,vmware/vcd-api-tools,master,maven,,java8,,,,
 ,vmware/vidm-saml-toolkit,master,maven,,java8,,,,
 ,vmware/vrealize-orchestrator-plugin-for-alb,master,maven,,java8,,,,
@@ -37242,7 +37242,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,waylau/mongodb-file-server,master,,,java8,,,,
 ,waylau/netty-4-user-guide-demos,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,waylife/DemoCollections,master,,,java8,,,TRUE,Top-level build tool file is missing
-,wayneqs/SGBankAccount,master,,,java8,,,,
+,wayneqs/SGBankAccount,master,,,java8,,,TRUE,Gradle wrapper 4.4.1 is not supported
 ,wayneqs/grabber,master,,,java8,,,,
 ,wayu002/AlipayQRHook,master,,,java8,,,,
 ,waywardsh/WebServlets,master,maven,,java8,,,,
@@ -37385,7 +37385,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,wheelerswebservices/cgc-azure-resume,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,wheelmanstudio/parking-api,master,maven,,java8,,,,
 ,whichbuffer/CryptText,master,,,java8,,,,
-,whilu/AndroidTagView,master,,,java8,,,,
+,whilu/AndroidTagView,master,,,java8,,,TRUE,Gradle wrapper 4.9 is not supported
 ,whilu/LMBluetoothSdk,master,,,java8,,,,
 ,whilu/TPShareLogin,master,,,java8,,,,
 ,whimaggot/Searchview,master,,gradle,java8,,,,
@@ -37428,7 +37428,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,wildfirechat/im-server,wildfirechat,maven,,java8,,,,
 ,wildfly-security/jboss-negotiation,master,maven,,java8,,,,
 ,wildfly-security/wildfly-elytron,1.x,maven,,java8,,,,
-,wildfly/galleon,main,maven,,java8,,,,
+,wildfly/galleon,main,maven,,java11,,,,
 ,wildfly/jandex,master,maven,,java8,,,,
 ,wildfly/jboss-ejb-client,4,maven,,java8,,,,
 ,wildfly/maven-plugins,master,maven,,java8,,,,
@@ -37548,7 +37548,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,wmaintw/DependencyCheck,master,maven,,java8,,,,
 ,wmaintw/appsec101-vba,master,,,java8,,,,
 ,wmarques/jhipsterSampleApplication,master,maven,,java8,,,,
-,wmixvideo/nfe,master,maven,,java8,,,,
+,wmixvideo/nfe,master,maven,,java11,,,,
 ,wmjmurphy/encryption,master,maven,,java8,,,,
 ,wmmitte/sngsjh,master,maven,,java8,,,,
 ,wms2/mywms,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -37560,7 +37560,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,wode490390/BotClient,master,maven,,java8,,,,
 ,wode490390/LobbyServer,master,maven,,java8,,,,
 ,woesss/JL-Mod,dev,,,java8,,,,
-,wojowoof/PianoPushups,master,,,java8,,,,
+,wojowoof/PianoPushups,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,wolearn/MvpFrame,master,,,java8,,,,
 ,wolfdale/Spaghetti-code,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,wolfika222/homework11,master,maven,,java8,,,,
@@ -37627,7 +37627,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,wqtwqt/gmall-parent,master,maven,,java8,,,,
 ,wqy131/being-code,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,wrlyonsjr/gradle-aggregate-jacoco,master,,,java8,,,,
-,wro4j/wro4j,master,maven,,java8,,,,
+,wro4j/wro4j,master,maven,,java11,,,,
 ,wrseasky/redisson-spring-boot-starter,master,maven,,java8,,,,
 ,wsaults/pal-tracker,master,,,java8,,,,
 ,wshanshi/jhipster,master,maven,,java8,,,,
@@ -37721,7 +37721,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,wuba/dl_inference,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,wucao/JDeploy,master,maven,,java8,,,,
 ,wucao/websocket-tail-demo,master,maven,,java8,,,,
-,wuchao226/FastEC,master,,,java8,,,,
+,wuchao226/FastEC,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,wuchong/flink-hackathon,master,maven,,java8,,,,
 ,wuchong/flink-sql-submit,master,maven,,java8,,,,
 ,wuchong/my-flink-project,master,maven,,java8,,,,
@@ -37796,7 +37796,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,x-falcon/Virtual-Hosts,main,,,java8,,,,
 ,x-ream/acku,master,maven,,java8,,,,
 ,x-ream/sqli,master,maven,,java8,,,,
-,x-stream/xstream,master,maven,,java8,,,,
+,x-stream/xstream,master,maven,,java11,,,,
 ,x-xira25-x/JhipsterMonoMySql,master,maven,,java8,,,,
 ,x-xira25-x/ProjetJHipster1,master,maven,,java8,,,,
 ,x2on/gradle-cocoapods-plugin,master,,,java8,,,TRUE,Build uses Gradle 2.x
@@ -37852,7 +37852,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,xebialabs-community/xlr-docker-gradle-plugin,master,,,java8,,,TRUE,Build uses Gradle 2.x
 ,xebialabs-community/xlr-flowdock-plugin,master,,,java8,,,,
 ,xebialabs-community/xlr-servicenow-plugin,master,,,java8,,,,
-,xebialabs/overcast,master,,,java8,,,,
+,xebialabs/overcast,master,,,java11,,,,
 ,xebialabs/overthere,master,,,java11,,,,
 ,xebialabs/rest-o-rant-api,master,,,java8,,,,
 ,xebiaww/tryout,master,maven,,java8,,,,
@@ -37868,7 +37868,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,xenv/gushici,master,maven,,java8,,,,
 ,xeodou/react-native-player,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,xeraa/microservice-monitoring,master,,,java8,,,TRUE,Top-level build tool file is missing
-,xerial/sqlite-jdbc,master,maven,,java8,,,,
+,xerial/sqlite-jdbc,master,maven,,java11,,,,
 ,xerikssonx/cloud_note,master,maven,,java8,,,,
 ,xerikssonx/textpad,master,maven,,java8,,,,
 ,xetorthio/jedis,master,maven,,java8,,,,
@@ -37983,7 +37983,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,xmatters/cthulhu-chaos-testing,master,,,java8,,,,
 ,xmeng1/jhipster-xin,master,maven,,java8,,,,
 ,xmlking/cdc-images,master,,,java8,,,,
-,xmlking/kafka-kstream,master,,,java8,,,,
+,xmlking/kafka-kstream,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,xmlking/ml-experiments,master,,,java8,,,,
 ,xmlking/storm-playground,master,,gradle,java8,,,,
 ,xmlking/sumo,master,maven,,java8,,,,
@@ -38031,7 +38031,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,xu942122587/Java-Interview,master,maven,,java8,,,,
 ,xuanthinh2612/m3-case-study-shopping--website,master,,,java8,,,,
 ,xucyy/netty_ym,master,maven,,java8,,,,
-,xudjx/webprogress,master,,,java8,,,,
+,xudjx/webprogress,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,xuehuayous/Android-LoopView,master,,,java8,,,,
 ,xuehuayous/PullToRefresh-Demo,master,,,java8,,,,
 ,xuender/unidecode,master,maven,,java8,,,,
@@ -38106,7 +38106,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,xynuSuMu/job,master,maven,,java8,,,,
 ,xyunkyung/smartWeb,main,,,java8,,,TRUE,Top-level build tool file is missing
 ,xyyxhcj/vpi,master,,,java8,,,TRUE,Top-level build tool file is missing
-,xyzBits/AdvancedJava,master,maven,,java8,,,,
+,xyzBits/AdvancedJava,master,maven,,java11,,,,
 ,xyzrlee/api,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,xzel23/javafx-gradle-plugin,master,,,java11,,,,
 ,xzer/run-jetty-run,master,maven,,java8,,,,
@@ -38172,7 +38172,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,yakworks/gradle-plugins,master,,,java17,,,,
 ,yalday-dev/yaldayMono,master,maven,,java8,,,,
 ,yale8848/RetrofitCache,master,,,java8,,,,
-,yamcs/yamcs,master,maven,,java8,,,,
+,yamcs/yamcs,master,maven,,java11,,,,
 ,yamilacasarini/restopassServer,master,maven,,java8,,,,
 ,yamilmedina/appgallery-publisher,master,,,java8,,,,
 ,yaming116/UpdateApp,master,,,java8,,,,
@@ -38344,7 +38344,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,yeokm1/docs-to-pdf-converter,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,yeqifu/carRental,master,maven,,java8,,,,
 ,yerias/tunan-hive-metastore,master,maven,,java8,,,,
-,yeriomin/YalpStore,master,,,java8,,,,
+,yeriomin/YalpStore,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,yeriomin/play-store-api,master,,,java8,,,,
 ,yescooler/jhip,master,maven,,java8,,,,
 ,yescpu/KeyboardChangeListener,master,,,java8,,,,
@@ -38394,7 +38394,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,yindanqing925/demo-parent,master,maven,,java8,,,,
 ,ying0904/first,master,maven,,java8,,,,
 ,yingLanNull/CircleAlarmTimerView,master,,,java8,,,,
-,yingLanNull/HideKeyboard,master,,,java8,,,,
+,yingLanNull/HideKeyboard,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,yingLanNull/ScrollLayout,master,,gradle,java8,,,,
 ,yingLanNull/ShadowImageView,master,,,java8,,,,
 ,yingw/BackendServiceDemo,master,maven,,java8,,,,
@@ -38480,7 +38480,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,youlookwhat/ByWebView,master,,,java8,,,,
 ,youlookwhat/CloudReader,master,,,java8,,,,
 ,youmu178/TabSwitchView,master,,,java8,,,,
-,young-coder-vn/invoice,main,maven,,java8,,,,
+,young-coder-vn/invoice,main,maven,,java11,,,,
 ,young891221/Spring-Boot-Community-Rest,master,,,java8,,,,
 ,youngho/magi,master,,,java8,,,,
 ,youni123/fproject,master,,,java8,,,,
@@ -38577,7 +38577,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,yunarta/works-enteprise-repo-gradle-plugin,master,,,java8,,,,
 ,yunarta/works-jacoco-gradle-plugin,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.
 ,yunjugwon/test-board-service,main,maven,,java8,,,,
-,yunsean/yoga,master,,,java8,,,,
+,yunsean/yoga,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,yuntac/devops,master,maven,,java8,,,,
 ,yunusemregul/koubilgi,master,,,java8,,,,
 ,yupzip/wsdl2java,master,,,java8,,,,
@@ -38597,7 +38597,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,yushulx/myget-barcode-sample,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,yusufsoysal/kasa,master,maven,,java8,,,,
 ,yusuke/sign-in-with-twitter,master,maven,,java8,,,,
-,yusuke/twitter4j,master,maven,,java8,,,,
+,yusuke/twitter4j,master,maven,,java17,,,,
 ,yuteng2014/gradle-plugin,master,,,java8,,,,
 ,yutthagarn/jhipsterSampleApplication,master,maven,,java8,,,,
 ,yutuer/javatools,master,maven,,java8,,,,
@@ -38633,7 +38633,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,yydcdut/SlideAndDragListView,master,,,java8,,,,
 ,yyha/spring-boot-seckill,master,maven,,java8,,,,
 ,yyk5920/teachServer,master,maven,,java8,,,,
-,yylat/dev-notifier,master,,,java8,,,,
+,yylat/dev-notifier,master,,,java8,,,TRUE,Gradle wrapper 4.6 is not supported
 ,yyuu/jetty-nosql-memcached,master,maven,,java8,,,,
 ,yzcheng90/X-SpringBoot,master,maven,,java8,,,,
 ,yzddmr6/Java-Shellcode-Loader,master,maven,,java8,,,,
@@ -38690,10 +38690,10 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,zaproxy/gradle-plugin-crowdin,main,,,java8,,,,
 ,zaproxy/zap-admin,master,,,java8,,,,
 ,zaproxy/zap-api-java,main,,,java8,,,,
-,zaproxy/zap-extensions,main,,,java8,,,,
+,zaproxy/zap-extensions,main,,,java11,,,,
 ,zaproxy/zap-libs,main,,,java8,,,,
 ,zaproxy/zaproxy,main,,,java8,,,,
-,zaproxy/zest,main,,,java8,,,,
+,zaproxy/zest,main,,,java11,,,,
 ,zarrouq/cashback,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,zazaluMonster/MySpider,master,maven,,java8,,,,
 ,zbazztian/acio,main,maven,,java8,,,,
@@ -38736,9 +38736,9 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,zenoyang/web-click-flow,master,,,java8,,,TRUE,Top-level build tool file is missing
 ,zensezz/GRMS,master,maven,,java8,,,,
 ,zensoftio/gradle-versioning-plugin,master,,,java8,,,,
-,zentity-io/zentity,main,maven,,java8,,,,
+,zentity-io/zentity,main,maven,,java11,,,,
 ,zenvisage/vispilot,master,maven,,java8,,,,
-,zergsar/SkillBoxProj,master,maven,,java8,,,,
+,zergsar/SkillBoxProj,master,maven,,java11,,,,
 ,zerh/CONTACT-CHALLENGE-MASTER,master,maven,,java8,,,,
 ,zero-second-delay/javagent,master,maven,,java8,,,,
 ,zero5/javasmoke,master,,,java8,,,TRUE,Top-level build tool file is missing
@@ -38954,7 +38954,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,zimthug/ianvs-backend,master,maven,,java8,,,,
 ,zinaLacina/jhipster-with-mongodb,master,maven,,java8,,,,
 ,zincPower/JRecycleView,master,,,java8,,,,
-,zincPower/UI2018,master,,,java8,,,,
+,zincPower/UI2018,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,zinebsa/immobilisation,master,maven,,java8,,,,
 ,zinggAI/zingg,main,maven,,java8,,,,
 ,zinou-java/prime_faces,master,maven,,java8,,,,
@@ -39051,7 +39051,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,zuloloxi/java-agent-asm-javassist-test,master,maven,,java8,,,,
 ,zulumike31/app1,master,maven,,java8,,,,
 ,zunzhuowei/hbsoo-project,main,,,java8,,,,
-,zurche/plain-pie,master,,,java8,,,,
+,zurche/plain-pie,master,,,java8,,,TRUE,Gradle wrapper 4.4 is not supported
 ,zwiger/TabViewPager,master,,,java8,,,,
 ,zx63/TronWallet,master,maven,,java8,,,,
 ,zxfnicholas/CameraSDK,master,,,java8,,,TRUE,Build uses Gradle 4.x prior to 4.10 and the artifactory plugin does not support these builds.


### PR DESCRIPTION
Based on https://public.moderne.io/results/WEI57/data-tables
Which contains 4814 failed runs;
172 used outdated Gradle wrappers;
another 480 now get a new Java version.
