### PR TITLE
Add `add-github-organization.sh` and de-duplicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,7 @@ This file should be configured in Jenkins master through `Manage Jenkins > Globa
 To add a repository to the ingestion process, add a row to `repos.csv` with the repository name and branch.
 
 ```shell
-$ gh repo list openrewrite --language java --no-archived --source --limit 1000 --json nameWithOwner,defaultBranchRef --template '{{range .}},{{.nameWithOwner}},{{.defaultBranchRef.name}},,,java17,,,,{{"\n"}}{{end}}' | sort > new.csv
-$ head -n 1 repos.csv > header.csv
-$ tail -n +2 repos.csv > old.csv
-$ mv header.csv repos.csv
-$ cat old.csv new.csv | LC_COLLATE=C sort | uniq >> repos.csv
-$ rm old.csv new.csv
+$ ./add-github-organization.sh openrewrite
 ```
 
 Then trigger a manual run of https://github.com/moderneinc/moderne-cli/actions/workflows/jenkins.yml to create the Jenkins jobs, potentially with a prefix filter.

--- a/add-github-organization.sh
+++ b/add-github-organization.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+
+gh repo list $1 --language java --no-archived --source --limit 1000 --json nameWithOwner,defaultBranchRef --template '{{range .}},{{.nameWithOwner}},{{.defaultBranchRef.name}},,,java17,,,,{{"\n"}}{{end}}' | sort > new.csv
+# Save the header
+head -n 1 repos.csv > header.csv
+# Copy the data without the header
+tail -n +2 repos.csv > old.csv
+mv header.csv repos.csv
+# Join the old and new data, deduplicate, and sort
+# join merges the data together based upon the columns scmHost,repoName,repoBranch preserving duplicates from the new file
+# awk replaces the empty jdkTool with java17, which is the default, and was stripped by join from the new file
+join -t, -a2 -j1 -o2.2,2.3,2.4,1.5,1.6,1.7,1.8,1.9,1.10,1.11 <(<old.csv awk -F, '{print $1"-"$2"-"$3","$0}' | sort -k1,1 ) <(<new.csv awk -F, '{print $1"-"$2"-"$3","$0}' | sort -k1,1 ) | awk -F ',' -v OFS=',' '$6 == "" { $6 = "java17" }1' | LC_COLLATE=C sort | uniq >> new_deduplicated.csv
+# Join the old and new deduplicate data, and sort
+cat old.csv new_deduplicated.csv | LC_COLLATE=C sort | uniq >> repos.csv
+rm old.csv new.csv new_deduplicated.csv

--- a/repos.csv
+++ b/repos.csv
@@ -31019,6 +31019,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,openrewrite/rewrite-github-actions,main,,,java17,,,,
 ,openrewrite/rewrite-gradle-plugin,main,,,java17,,,,
 ,openrewrite/rewrite-gradle-tooling-model,main,,,java17,,,,
+,openrewrite/rewrite-houston-jug,main,,,java17,,,,
 ,openrewrite/rewrite-java-annotproc,main,,,java17,,,,
 ,openrewrite/rewrite-java-dependencies,main,,,java17,,,,
 ,openrewrite/rewrite-java-security,main,,,java17,,,,


### PR DESCRIPTION
Without this change, the following new redundant line would have been added:
```csv
,openrewrite/rewrite-maven-plugin,main,,,java17,,,,
```

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>
