### PR TITLE
Index commons-text-api-plugin with Java 11

### DIFF
--- a/repos.csv
+++ b/repos.csv
@@ -23101,7 +23101,7 @@ scmHost,repoName,repoBranch,mavenTool,gradleTool,jdkTool,repoStyle,repoBuildActi
 ,jenkinsci/commons-httpclient3-api-plugin,master,,,java17,,,,
 ,jenkinsci/commons-lang-api-plugin,main,maven,,java8,,,,
 ,jenkinsci/commons-lang3-api-plugin,main,maven,,java11,,,,
-,jenkinsci/commons-text-api-plugin,main,maven,,java8,,,,
+,jenkinsci/commons-text-api-plugin,main,maven,,java11,,,,
 ,jenkinsci/compact-columns-plugin,main,,,java17,,,,
 ,jenkinsci/compact-columns-plugin,master,maven,,java8,,,,
 ,jenkinsci/composer-dependency-analysis-plugin,master,maven3.3.9,,java8,,,,


### PR DESCRIPTION
This is a plugin I maintain that has moved to requiring Java 11

cc @timtebeek 