### PR TITLE
Add a script to search and add githubs repos for a specific language

### DIFF
--- a/search-and-add-github-repos.sh
+++ b/search-and-add-github-repos.sh
@@ -26,3 +26,6 @@ cat out/gh.json | jq -r '.[] | "      {
 # Merge `new.csv` to `repos.csv`
 cd parser/
 ./gradlew build && java -cp build/libs/parser-1.0-SNAPSHOT.jar io.moderne.jenkins.ingest.Merger ../repos.csv  ../out/new.csv
+
+# Quick analysis of largest organizations
+cut --delimiter='/' --fields=1 repos.csv | sort | uniq -c | sort -h | tail -n 20

--- a/search-and-add-github-repos.sh
+++ b/search-and-add-github-repos.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -ex
+
+# This script is exclusively developed for parser development purposes. It serves the specific use case of ingesting GitHub repositories internally for SAAS.
+
+# Create out folder if not exist
+mkdir -p out
+
+# Search and add github repos by language, change the below language
+
+# generate `gh.json` which includes repo fullName and branch name,
+# Manually customize the language and adjust the count below according to your specific requirements.
+# option to add filter: --updated="> 2023-11-21"
+gh search repos --language javascript --visibility public --limit 1000 --json fullName,defaultBranch > out/gh.json
+
+# generate `new.csv`, which will be merged to `repos.csv`
+cat out/gh.json | jq -r '.[] | ",\(.fullName),\(.defaultBranch),,,,,,,"' > out/new.csv
+
+# generate `repos.json`, which will be used to update `ownership.json`
+cat out/gh.json | jq -r '.[] | "      {
+        \"origin\": \"github.com\",
+        \"path\": \"" + .fullName + "\",
+        \"branch\": \"" + .defaultBranch + "\"
+      },"' | sed '$s/,$//' > out/repos-content.json
+
+# Quick analysis of largest organizations
+cut --delimiter='/' --fields=1 repos.csv | sort | uniq -c | sort -h | tail -n 20
+
+# Merge `new.csv` to `repos.csv`
+cd parser/
+./gradlew build && java -cp build/libs/parser-1.0-SNAPSHOT.jar io.moderne.jenkins.ingest.Merger ../repos.csv  ../out/new.csv

--- a/search-and-add-github-repos.sh
+++ b/search-and-add-github-repos.sh
@@ -23,9 +23,6 @@ cat out/gh.json | jq -r '.[] | "      {
         \"branch\": \"" + .defaultBranch + "\"
       },"' | sed '$s/,$//' > out/repos-content.json
 
-# Quick analysis of largest organizations
-cut --delimiter='/' --fields=1 repos.csv | sort | uniq -c | sort -h | tail -n 20
-
 # Merge `new.csv` to `repos.csv`
 cd parser/
 ./gradlew build && java -cp build/libs/parser-1.0-SNAPSHOT.jar io.moderne.jenkins.ingest.Merger ../repos.csv  ../out/new.csv


### PR DESCRIPTION
Add `search-and-add-github-repos.sh` to 
1. Search for github repos for a specific language. 
2. generate a `csv` and merge it to `repos.csv`
3. generate `json` content to be added to `ownership.json` for SAAS groups. 