### PR TITLE
refactor: Migrate to Java 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: build
         timeout-minutes: 20
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.java.migrate.UpgradeToJava21?organizationId=TW9kZXJuZQ%3D%3D